### PR TITLE
Corrected lang identifiers and syntax

### DIFF
--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/4-erc20-open-zeppelin/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/4-erc20-open-zeppelin/+page.md
@@ -29,8 +29,8 @@ forge install OpenZeppelin/openzeppelin-contracts --no-commit
 
 Once installed you'll see the ERC20 contract from OpenZeppelin within `lib/openzeppelin-contracts/token/ERC20/ERC20.sol`. Let's add a remapping in our foundry.toml to make importing a little easier on us.Within foundry.toml add the line:
 
-```js
-remappings = ["@openzeppelin=lib/openzeppelin-contracts"];
+```toml
+remappings = ["@openzeppelin=lib/openzeppelin-contracts"]
 ```
 
 We can now import and inherit this contract into `OurToken.sol`!

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/15-svg-deploy/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/15-svg-deploy/+page.md
@@ -127,7 +127,7 @@ Nailed it! Our solidity scripted encoding is working just like our command line.
 
 Before we can allow Foundry to read our files into our deploy script, we'll need to set some permissions in `foundry.toml`. Add this to your `foundry.toml`:
 
-```js
+```toml
 fs_permissions = [{access = "read", path = "./img/"}]
 ```
 

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/3-foundry-setup/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/3-foundry-setup/+page.md
@@ -53,12 +53,12 @@ forge install OpenZeppelin/openzeppelin-contracts --no-commit
 
 To make things a little easier on ourselves, we can add this as a remapping to our `foundry.toml`. This remapping allows us to use some short-hand when importing from this directory.
 
-```js
-[profile.default];
-src = "src";
-out = "out";
-libs = ["lib"];
-remappings = ["@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"];
+```toml
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+remappings = ["@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"]
 ```
 
 Now we can import and inherit the ERC721 contract into `BasicNft.sol`

--- a/courses/advanced-foundry/3-develop-defi-protocol/17-defi-handler-fuzz-tests/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/17-defi-handler-fuzz-tests/+page.md
@@ -182,9 +182,9 @@ In our example, the fuzz tester took 18 random inputs to find our edge case.
 
 However, we can customize how many attempts the fuzzer makes within our foundry.toml by adding a section like:
 
-```js
-[fuzz];
-runs = 1000;
+```toml
+[fuzz]
+runs = 1000
 ```
 
 Now, if we adjust our example function...

--- a/courses/advanced-foundry/3-develop-defi-protocol/18-defi-handler-stateful-fuzz-tests/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/18-defi-handler-stateful-fuzz-tests/+page.md
@@ -45,11 +45,11 @@ Let's finally start applying this methodology to our code base.
 
 The first thing we want to do to prepare our stateful fuzzing suite is to configure some of the fuzzer options in our `foundry.toml`.
 
-```js
-[invariant];
-runs = 128;
-depth = 128;
-fail_on_revert = false;
+```toml
+[invariant]
+runs = 128
+depth = 128
+fail_on_revert = false
 ```
 
 Adding the above to our foundry.toml will configure our fuzz tests to attempt `128 runs` and make `128 calls` in each run (depth). We'll go over `fail_on_revert` in more detail soon.

--- a/courses/advanced-foundry/3-develop-defi-protocol/4-defi-decentralized-stablecoin/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/4-defi-decentralized-stablecoin/+page.md
@@ -107,12 +107,12 @@ forge install openzeppelin/openzeppelin-contracts --no-commit
 And of course, we can add our remappings to our
 `foundry.toml`.
 
-```js
-[profile.default];
-src = "src";
-out = "out";
-libs = ["lib"];
-remappings = ["@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts"];
+```toml
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+remappings = ["@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts"]
 ```
 
 Rather than importing a standard ERC20 contract, we'll be leveraging the ERC20Burnable extention of this standard. ERC20Burnable includes `burn` functionality for our tokens which will be important when we need to take the asset out of circulation to support stability.

--- a/courses/advanced-foundry/3-develop-defi-protocol/7-defi-mint-dsc/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/7-defi-mint-dsc/+page.md
@@ -193,11 +193,11 @@ forge install smartcontractkit/chainlink-brownie-contracts@0.6.1 --no-commit
 
 And of course, we'll append this to our remappings within `foundry.toml`.
 
-```js
+```toml
 remappings = [
   "@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts",
   "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts",
-];
+]
 ```
 
 Alright, back to our `getUsdValue` function.

--- a/courses/advanced-foundry/4-merkle-airdrop/2-project-setup/+page.md
+++ b/courses/advanced-foundry/4-merkle-airdrop/2-project-setup/+page.md
@@ -16,7 +16,7 @@ The token that we are going to airdrop will be a ERC20 token. In the same direct
 
 In the `foundry.toml` file we the spcify a remapping:
 
-```
+```toml
 remappings = [ '@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/']
 ```
 

--- a/courses/advanced-foundry/4-merkle-airdrop/6-merkle-tree-script/+page.md
+++ b/courses/advanced-foundry/4-merkle-airdrop/6-merkle-tree-script/+page.md
@@ -12,7 +12,7 @@ To access our private variables in the `MerkleAirdrop` contract, we need to add 
 
 We can then create a test file named `/test/MerkleAirdropTest.sol` and add some remappings in `foundy.toml`:
 
-```
+```toml
 remappings = [
     'murky/=lib/murky/',
     '@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/',

--- a/courses/advanced-foundry/5-upgradeable-smart-contracts/4-uups/+page.md
+++ b/courses/advanced-foundry/5-upgradeable-smart-contracts/4-uups/+page.md
@@ -91,10 +91,10 @@ forge install OpenZeppelin/openzeppelin-contracts-upgradeable --no-commit
 
 Once installed we can add our remappings to our `foundry.toml`
 
-```js
+```toml
 remappings = [
   "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts",
-];
+]
 ```
 
 And now, we can import UUPSUpgradeable into BoxV1.sol and break down how it's applied.

--- a/courses/advanced-foundry/6-account-abstraction/23-zksync-simulations/+page.md
+++ b/courses/advanced-foundry/6-account-abstraction/23-zksync-simulations/+page.md
@@ -115,7 +115,7 @@ function incrementMinNonceIfEquals(uint256 _expectedNonce) external onlySystemCa
 
 To do this, we are first going to have to add a flag under our `remappings` in `foundry.toml`.
 
-```js
+```toml
 is-system = true
 ```
 

--- a/courses/advanced-foundry/6-account-abstraction/5-validate-user-op/+page.md
+++ b/courses/advanced-foundry/6-account-abstraction/5-validate-user-op/+page.md
@@ -62,8 +62,8 @@ forge install openzeppelin/openzeppelin-contracts@v5.0.2 --no-commit
 
 Before we import `Ownable`, we need to add it our remappings. Go to `foundry.toml` and add the following.
 
-```js
-remappings = ["@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"];
+```toml
+remappings = ["@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"]
 ```
 
 Now we can head back to our `MinimalAccount` contract and import it.

--- a/courses/advanced-foundry/7-daos/3-setup/+page.md
+++ b/courses/advanced-foundry/7-daos/3-setup/+page.md
@@ -46,8 +46,8 @@ forge install openzeppelin/openzeppelin-contracts --no-commit
 
 And naturally we can add our remapping...
 
-```js
-remappings = ["@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"];
+```toml
+remappings = ["@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"]
 ```
 
 The start of our contract should look very familiar.

--- a/courses/formal-verification/1-horse-store/62-horsestorev2-introduction/+page.md
+++ b/courses/formal-verification/1-horse-store/62-horsestorev2-introduction/+page.md
@@ -102,7 +102,7 @@ You should also add an interface IHorseStore.sol to this folder, you can copy an
 
 The final bit of preparation we'll need is to adjust our `foundry.toml` to include our new remappings.  Our remappings should look like:
 
-```js
+```toml
 remappings = [
     'foundry-huff/=lib/foundry-huff/src/',
     '@openzeppelin/=lib/openzeppelin-contracts/',

--- a/courses/foundry/2-foundry-fund-me/4-finishing-the-setup/+page.md
+++ b/courses/foundry/2-foundry-fund-me/4-finishing-the-setup/+page.md
@@ -42,7 +42,7 @@ But if you open the `FundMe.sol` you'll see that we are importing `{AggregatorV3
 
 Open `foundry.toml`. Below the last line of `[profile.default]` paste the following:
 
-```
+```toml
 remappings = ['@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/']
 ```
 

--- a/courses/security/1-review/14-fork-tests/+page.md
+++ b/courses/security/1-review/14-fork-tests/+page.md
@@ -28,9 +28,9 @@ function setUp() public {
 
 > Note: `mainnet` will need to be set as an alias in your `foundry.toml` under a new variable `[rpc_endpoints]`
 
-```js
-[rpc_endpoints];
-mainnet = "{MAINNET_RPC_URL}";
+```toml
+[rpc_endpoints]
+mainnet = "{MAINNET_RPC_URL}"
 ```
 
 With the above in place running the following will run your tests with respect to a fork of a live chain!

--- a/courses/security/1-review/4-installing-libraries/+page.md
+++ b/courses/security/1-review/4-installing-libraries/+page.md
@@ -22,7 +22,7 @@ forge install OpenZeppelin/openzeppelin-contracts --no-commit
 
 Now, navigate to the `foundry.toml` file in your project directory. Here, specify the remappings by setting `@openzeppelin/contracts` equal to `lib/openzeppelin-contracts/contracts`. This sets up the path for the compiler to locate OpenZeppelin contracts.
 
-```markdown
+```toml
 remappings = ['@openzeppelin/contracts=lib/openzeppelin-contracts/contracts']
 ```
 


### PR DESCRIPTION
In a few of the files, instructions for adding data to the foundry.toml file had a semicolon at the end of the line, which is not valid syntax for TOML. Additionally, some of the code blocks had incorrect language identifiers.