### PR TITLE
Written lesson cleanup: Storage Factory

### DIFF
--- a/courses/solidity/2-storage-factory/1-factory-introduction/+page.md
+++ b/courses/solidity/2-storage-factory/1-factory-introduction/+page.md
@@ -6,7 +6,7 @@ _You can follow along with the video course from here._
 
 ### Introduction
 
-You can find the code for this section in the [Remix Storage Factory Github repository](https://github.com/cyfrin/remix-storage-factory-f23). In these nine lessons we'll work with three new contracts:
+You can find the code for this section in the [Remix Storage Factory Github repository](https://github.com/cyfrin/remix-storage-factory-f23). In these nine lessons, we'll work with three new contracts:
 
 1. `SimpleStorage.sol` - the contract we build in the previous section, with some modifications
 2. `AddFiveStorage.sol` - a child contract of `SimpleStorage` that leverages _inheritance_
@@ -30,8 +30,6 @@ It's possible to interact with this newly deployed `SimpleStorage` via the `stor
 
 The **`sfGet`** function, when given the input '0', will indeed return the number provided by the previous function. The **address** of the `SimpleStorage` contract can then be retrieved by clicking on the get function `listOfSimpleStorageContracts`.
 
-::image{src='/solidity/remix/lesson-3/setting-up/graph-1.png' style='width: 100%; height: auto;'}
-        
 ### Conclusion
 The `StorageFactory` contract manages numerous instances of an external contract `SimpleStorage`. It provides functionality to deploy new contract instances dynamically and allows for the storage and retrieval of values from each instance. These instances are maintained and organized within an array, enabling efficient tracking and interaction.
 

--- a/courses/solidity/2-storage-factory/2-setting-up-the-factory/+page.md
+++ b/courses/solidity/2-storage-factory/2-setting-up-the-factory/+page.md
@@ -10,7 +10,7 @@ In this `StorageFactory` setup, we'll explore what _composability_ means, showin
 
 ### StorageFactory setup
 
-You can begin by visiting the [Github repository of the previous section](https://github.com/cyfrin/remix-simple-storage-f23) and copying the contract `SimpleStorage` inside Remix.
+You can begin by visiting the [Github repository of the previous section](https://github.com/cyfrin/remix-simple-storage-cu) and copying the contract `SimpleStorage` inside Remix.
 This contract allows to store a favorite number, a list of people with their favorite number, a mapping and different functionalities to interact with them.
 This lesson aims to create a **new contract** that can deploy and interact with `SimpleStorage`.
 
@@ -26,7 +26,7 @@ pragma solidity ^0.8.18;
 contract StorageFactory {
 
     function createSimplestorageContract() public {
-        //how does StorageFactory know what SimpleStorage looks like?
+        // How does StorageFactory know what SimpleStorage looks like?
     }
 }
 ```

--- a/courses/solidity/2-storage-factory/3-deploying-a-contract-from-a-contract/+page.md
+++ b/courses/solidity/2-storage-factory/3-deploying-a-contract-from-a-contract/+page.md
@@ -25,7 +25,8 @@ contract StorageFactory {
 }
 ```
 
-> 👀❗**IMPORTANT**:br > `SimpleStorage` on the left and `simpleStorage` on the right are treated as entirely distinct entities due to their differing capitalization. `Simple Storage` refers to the contract type while `simpleStorage` refers to the variable name.
+> 👀❗**IMPORTANT**:br 
+> `SimpleStorage` on the left and `simpleStorage` on the right are treated as entirely distinct entities due to their differing capitalization. `Simple Storage` refers to the contract type while `simpleStorage` refers to the variable name.
 
 When the `new` keyword is used, the compiler recognizes the intention to deploy a new contract instance. After compiling, we can proceed to deploy it.
 

--- a/courses/solidity/2-storage-factory/5-ai-help-ii/+page.md
+++ b/courses/solidity/2-storage-factory/5-ai-help-ii/+page.md
@@ -25,7 +25,7 @@ We can ask the AI to clarify it by:
 
 This is the AI prompt:
 
-````
+````text
 Hi, I'm having a hard time understanding the difference between these simple storages on this line:
 ```// paste the confusing line of code here```
 Here is my full code:

--- a/courses/solidity/2-storage-factory/7-inheritance-in-solidity/+page.md
+++ b/courses/solidity/2-storage-factory/7-inheritance-in-solidity/+page.md
@@ -11,7 +11,7 @@ In this lesson, we are going to introduce the concept of **inheritance** and **o
 ### Inheritance
 
 We are going to enhance the `SimpleStorage` contract by adding a new functionality: the ability to add five (5) to the stored `favoriteNumber`.
-To achieve this, we could duplicate the existing `SimpleStorage` contract and make changes to the new version. However, this approach leads to redundant code. A better practice could be to utilize **inheritance**, wich is the mechanism that allows the `AddFiveStorage` contract to derive all the functionalities of `SimpleStorage`.
+To achieve this, we could duplicate the existing `SimpleStorage` contract and make changes to the new version. However, this approach leads to redundant code. A better practice could be to utilize **inheritance**, which is the mechanism that allows the `AddFiveStorage` contract to derive all the functionalities of `SimpleStorage`.
 
 Let's begin by creating a new file `AddFiveStorage.sol` and name-importing `SimpleStorage.sol`:
 


### PR DESCRIPTION
The image link is broken.
However, when going to the location of where the image should be (https://github.com/Cyfrin/Updraft/tree/main/static/solidity/remix/lesson-3/setting-up), the images are from a previous version of the lesson which does not have the relevant information to what was mentioned in the video lesson.
The written lesson has enough information to match the video lesson.
It is likely okay to remove the broken image.

![Screenshot 2024-09-23 at 3 40 31 PM](https://github.com/user-attachments/assets/4a5dd8f9-5c6e-4797-9297-2d7c76ad3d60)
