### PR TITLE
Written lesson cleanup: Fund Me

### DIFF
--- a/courses/solidity/3-fund-me/1-fund-me-intro/+page.md
+++ b/courses/solidity/3-fund-me/1-fund-me-intro/+page.md
@@ -19,7 +19,7 @@ For this project, we will be using two contracts: `FundMe`, the main crowdfundin
 
 Once `FundMe` is deployed on Remix, you'll notice a set of _functions_, including a new red button labelled `fund`, indicating that the function is _payable_. A payable function allows you to send native blockchain currency (e.g., Ethereum, Polygon, Avalanche) to the contract.
 
-We'll additionally indicate a **minimum USD amount** to send to the contract when the function `fund` is called. To transfer funds to the `FundMe` contract, you can navigate to the _value section_ of the Remix deployment tab, enter a value (e.g. 0.1 ether) then hit `fund`. A Metamask transaction confirmation will appear, and the contract balance will remain zero until the transaction is finalized. Once completed, the contract balance will be updated to reflect the transferred amount.
+We'll additionally indicate a **minimum USD amount** to send to the contract when the function `fund` is called. To transfer funds to the `FundMe` contract, you can navigate to the _value section_ of the Remix deployment tab, enter a value (e.g. 0.1 ether) then hit `fund`. A MetaMask transaction confirmation will appear, and the contract balance will remain zero until the transaction is finalized. Once completed, the contract balance will be updated to reflect the transferred amount.
 
 The contract owner can then `withdraw` the funds. In this case, since we own the contract, the balance will be removed from the contract's balance and transferred to our wallet.
 

--- a/courses/solidity/3-fund-me/10-getting-prices-from-chainlink/+page.md
+++ b/courses/solidity/3-fund-me/10-getting-prices-from-chainlink/+page.md
@@ -18,13 +18,13 @@ AggregatorV3Interface priceFeed = AggregatorV3Interface(0x1b44F3514812d835EB1BDB
 
 We can call the `latestRoundData()` function on this interface to obtain several values, including the latest price.
 
-```js
+```solidity
 function latestRoundData() external view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
 ```
 
 For now, we'll focus on the `answer` value and ignore the other returned values by using commas as placeholders for the unneeded variables.
 
-```js
+```solidity
 function getLatestPrice() public view returns (int) {
     (,int price,,,) = priceFeed.latestRoundData();
     return price;
@@ -48,13 +48,13 @@ return price * 1e10;
 
 Typecasting, or type conversion, involves converting a value from one data type to another. In Solidity, not all data types can be converted due to differences in their underlying representations and the potential for data loss. However, certain conversions, such as from `int` to `uint`, are allowed.
 
-```js
+```solidity
 return uint(price) * 1e10;
 ```
 
 We can finalize our `view` function as follows:
 
-```js
+```solidity
 function getLatestPrice() public view returns (uint256) {
     (,int answer,,,) = priceFeed.latestRoundData();
     return uint(answer) * 1e10;

--- a/courses/solidity/3-fund-me/14-libraries/+page.md
+++ b/courses/solidity/3-fund-me/14-libraries/+page.md
@@ -26,23 +26,23 @@ library PriceConverter {}
 
 Let's copy `getPrice`, `getConversionRate`, and `getVersion` functions from the `FundMe.sol` contract into our new library, remembering to import the `AggregatorV3Interface` into `PriceConverter.sol`. Finally, we can mark all the functions as `internal`.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
 
 library PriceConverter {
- function getPrice() internal view returns (uint256) {
-    AggregatorV3Interface priceFeed = AggregatorV3Interface(0x694AA1769357215DE4FAC081bf1f309aDC325306);
-    (, int256 answer, , , ) = priceFeed.latestRoundData();
-    return uint256(answer * 10000000000);
- }
+    function getPrice() internal view returns (uint256) {
+        AggregatorV3Interface priceFeed = AggregatorV3Interface(0x694AA1769357215DE4FAC081bf1f309aDC325306);
+        (, int256 answer, , , ) = priceFeed.latestRoundData();
+        return uint256(answer * 10000000000);
+    }
 
- function getConversionRate(uint256 ethAmount) internal view returns (uint256) {
-    uint256 ethPrice = getPrice();
-    uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1000000000000000000;
-    return ethAmountInUsd;
+    function getConversionRate(uint256 ethAmount) internal view returns (uint256) {
+        uint256 ethPrice = getPrice();
+        uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1000000000000000000;
+        return ethAmountInUsd;
     }
 }
 ```
@@ -51,20 +51,20 @@ library PriceConverter {
 
 You can import the library in your contract and attach it to the desired type with the keyword `using`:
 
-```js
+```solidity
 import {PriceConverter} from "./PriceConverter.sol";
 using PriceConverter for uint256;
 ```
 
 The `PriceConverter` functions can then be called as if they are native to the `uint256` type. For example, calling the `getConversionRate()` function will now be changed into:
 
-```js
+```solidity
 require(msg.value.getConversionRate() >= minimumUsd, "didn't send enough ETH");
 ```
 
 Here, `msg.value`, which is a `uint256` type, is extended to include the `getConversionRate()` function. The `msg.value` gets passed as the first argument to the function. If additional arguments are needed, they are passed in parentheses:
 
-```js
+```solidity
 uint256 result = msg.value.getConversionRate(123);
 ```
 

--- a/courses/solidity/3-fund-me/15-safemath/+page.md
+++ b/courses/solidity/3-fund-me/15-safemath/+page.md
@@ -14,7 +14,7 @@ In this lesson, we will explore `SafeMath`, a widely used library before Solidit
 
 Let's begin by creating a new file called `SafeMathTester.sol` and adding a function `add` that increments the `bigNumber` state variable.
 
-```js
+```solidity
 // SafeMathTester.sol
 pragma solidity ^0.6.0;
 
@@ -22,7 +22,7 @@ contract SafeMathTester {
     uint8 public bigNumber = 255;
 
     function add() public {
-    bigNumber = bigNumber + 1;
+        bigNumber = bigNumber + 1;
     }
 }
 ```
@@ -35,7 +35,7 @@ Before Solidity version **0.8.0**, signed and unsigned integers were **unchecked
 
 `SafeMath.sol` provided a mechanism to revert transactions when the maximum limit of a `uint256` data type was reached. It was a typical security measure across contracts to avoid erroneous calculations and potential exploits.
 
-```js
+```solidity
 function add(uint a, uint b) public pure returns (uint) {
     uint c = a + b;
     require(c >= a, "SafeMath: addition overflow");
@@ -49,13 +49,13 @@ With the introduction of Solidity version 0.8, automatic checks for overflows an
 
 For scenarios where mathematical operations are known not to exceed a variable's limit, Solidity introduced the `unchecked` construct to make code more _gas-efficient_. Wrapping the addition operation with `unchecked` will _ignore the overflow and underflow checks_: if the `bigNumber` exceeds the limit, it will wrap its value to zero.
 
-```js
+```solidity
 uint8 public bigNumber = 255;
 
 function add() public {
     unchecked {
-    bigNumber = bigNumber + 1;
- }
+        bigNumber = bigNumber + 1;
+    }
 }
 ```
 
@@ -70,6 +70,6 @@ The evolution of Solidity and `SafeMath.sol` highlights the continuous advanceme
 
 1. 📕 Why was the `SafeMath` library widely used before version 0.8?
 2. 📕 Explain the meaning of integer overflow and integer underflow. Make an example using `uint16`.
-3. 📕 What happened after solidity version 0.8?
+3. 📕 What happened after Solidity version 0.8?
 4. 📕 What is the unchecked construct?
 5. 🧑‍💻 Modify the `SafeMathTester` contract by using the SafeMath library to prevent integer overflow.

--- a/courses/solidity/3-fund-me/18-sending-eth-from-a-contract/+page.md
+++ b/courses/solidity/3-fund-me/18-sending-eth-from-a-contract/+page.md
@@ -12,7 +12,7 @@ This lesson explores three different methods of sending ETH from one account to 
 
 The `transfer` function is the simplest way to send Ether to a recipient address:
 
-```js
+```solidity
 payable(msg.sender).transfer(amount); // the current contract sends the Ether amount to the msg.sender
 ```
 
@@ -24,7 +24,7 @@ However, `transfer` has a significant limitation. It can only use up to 2300 gas
 
 The `send` function is similar to `transfer`, but it differs in its behaviour:
 
-```js
+```solidity
 bool success = payable(msg.sender).send(address(this).balance);
 require(success, "Send failed");
 ```
@@ -35,7 +35,7 @@ Like `transfer`, `send` also has a gas limit of 2300. If the gas limit is reache
 
 The `call` function is flexible and powerful. It can be used to call any function **without requiring its ABI**. It does not have a gas limit, and like `send`, it returns a boolean value instead of reverting like `transfer`.
 
-```js
+```solidity
 (bool success, ) = payable(msg.sender).call{value: address(this).balance}("");
 require(success, "Call failed");
 ```
@@ -44,7 +44,8 @@ To send funds using the `call` function, we convert the address of the receiver 
 
 The `call` function returns two variables: a boolean for success or failure, and a byte object which stores returned data if any.
 
-> 👀❗**IMPORTANT**:br > `call` is the recommended way of sending and receiving Ethereum or other blockchain native tokens.
+> 👀❗**IMPORTANT**:br 
+> `call` is the recommended way of sending and receiving Ethereum or other blockchain native tokens.
 
 ### Conclusion
 

--- a/courses/solidity/3-fund-me/19-constructor/+page.md
+++ b/courses/solidity/3-fund-me/19-constructor/+page.md
@@ -16,7 +16,7 @@ One solution could be to create a function, `callMeRightAway`, to assign the rol
 
 A more efficient solution is to use a **constructor** function:
 
-```js
+```solidity
 constructor() {}
 ```
 
@@ -29,7 +29,7 @@ The constructor function is automatically called during contract deployment, wit
 
 We can use the constructor to set the contract's owner immediately after deployment:
 
-```js
+```solidity
 address public owner;
 constructor() {
     owner = msg.sender;
@@ -42,14 +42,14 @@ Here, we initialize the state variable `owner` with the contract deployer's addr
 
 The next step is to update the `withdraw` function to ensure it can only be called by the owner:
 
-```js
+```solidity
 function withdraw() public {
     require(msg.sender == owner, "must be owner");
- // rest of the function here
+    // rest of the function here
 }
 ```
 
-Before executing any withdrawal actions, we check that `msg.sender` is the owner. If the caller is not the owner, the operation **reverts** with the error message "must be the owner." This access restriction ensures that only the intended account can execute the function.
+Before executing any withdrawal actions, we check that `msg.sender` is the owner. If the caller is not the owner, the operation **reverts** with the error message "must be the owner" This access restriction ensures that only the intended account can execute the function.
 
 ### Conclusion
 

--- a/courses/solidity/3-fund-me/2-setup/+page.md
+++ b/courses/solidity/3-fund-me/2-setup/+page.md
@@ -38,7 +38,7 @@ The FundMe contract will have two primary functions that serve as the main inter
 
 First, let's code the `fund` function and leave the `withdraw` function commented out for the moment.
 
-```js
+```solidity
 contract FundMe {
     // send funds into our contract
     function fund() public {}

--- a/courses/solidity/3-fund-me/20-modifiers/+page.md
+++ b/courses/solidity/3-fund-me/20-modifiers/+page.md
@@ -12,7 +12,7 @@ In this lesson, we will explore **modifiers** and how they can simplify code wri
 
 If we build a contract with multiple _administrative functions_, that should only be executed by the contract owner, we might repeatedly check the caller identity:
 
-```js
+```solidity
 require(msg.sender == owner, "Sender is not owner");
 ```
 
@@ -24,7 +24,7 @@ Modifiers in Solidity allow embedding **custom lines of code** within any functi
 
 Here's how to create a modifier:
 
-```js
+```solidity
 modifier onlyOwner {
     require(msg.sender == owner, "Sender is not owner");
     _;
@@ -40,7 +40,7 @@ The underscore `_` placed in the body is a placeholder for the modified function
 
 For example, the `onlyOwner` modifier can be applied to the `withdraw` function like this:
 
-```js
+```solidity
 function withdraw(uint amount) public onlyOwner {
     // Function logic
 }

--- a/courses/solidity/3-fund-me/23-custom-errors/+page.md
+++ b/courses/solidity/3-fund-me/23-custom-errors/+page.md
@@ -18,15 +18,15 @@ Introduced in **Solidity 0.8.4**, custom errors can be used in `revert` statemen
 
 We can start by creating a custom error:
 
-```js
+```solidity
 error NotOwner();
 ```
 
 Then, we can replace the `require` function with an `if` statement, using the `revert` function with the newly created error:
 
-```js
+```solidity
 if (msg.sender != i_owner) {
- revert NotOwner();
+    revert NotOwner();
 }
 ```
 

--- a/courses/solidity/3-fund-me/24-receive-fallback/+page.md
+++ b/courses/solidity/3-fund-me/24-receive-fallback/+page.md
@@ -14,7 +14,7 @@ In Solidity, if Ether is sent to a contract without a `receive` or `fallback` fu
 
 To illustrate, let's create a simple contract:
 
-```js
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
@@ -33,22 +33,24 @@ contract FallbackExample {
 
 In this contract, `result` is initialized to zero. When Ether is sent to the contract, the `receive` function is triggered, setting `result` to one. If a transaction includes **data** but the specified function _does not exist_, the `fallback` function will be triggered, setting `result` to two. For a comprehensive explanation, refer to [SolidityByExample](https://solidity-by-example.org/fallback/).
 
-// Ether is sent to the contract
-// is msg.data empty?
-// / \
-// yes no
-// / \
-// receive() ? fallback()
-// / \
-// yes no
-// / \
-// receive() fallback()
+```text
+// Ether is sent to contract
+//      is msg.data empty?
+//          /   \
+//         yes  no
+//         /     \
+//    receive()?  fallback()
+//     /   \
+//   yes   no
+//  /        \
+//receive()  fallback()
+```
 
 ### Sending Ether to fundMe
 
 When a user sends Ether **directly** to the `fundMe` contract without calling the `fund` function, the `receive` function can be used to _redirect_ the transaction to the `fund` function:
 
-```js
+```solidity
 receive() external payable {
     fund();
 }

--- a/courses/solidity/3-fund-me/24-receive-fallback/+page.md
+++ b/courses/solidity/3-fund-me/24-receive-fallback/+page.md
@@ -8,7 +8,7 @@ _You can follow along with the video course from here._
 
 In Solidity, if Ether is sent to a contract without a `receive` or `fallback` function, the transaction will be **rejected**, and the Ether will not be transferred. In this lesson, we'll explore how to handle this scenario effectively.
 
-### receiv and fallback functions
+### receive and fallback functions
 
 `receive` and `fallback` are _special functions_ triggered when users send Ether directly to the contract or call non-existent functions. These functions do not return anything and must be declared `external`.
 

--- a/courses/solidity/3-fund-me/25-zksync-plugin-fix/+page.md
+++ b/courses/solidity/3-fund-me/25-zksync-plugin-fix/+page.md
@@ -1,13 +1,13 @@
 ---
-title: zkSync Plugin Fix
+title: ZKsync Plugin Fix
 ---
 
 _Follow along with the video_
 
 ---
 
-### zkSync Remix plugin minor bug
+### ZKsync Remix plugin minor bug
 
-As we saw in the _Simple Storage_ section, there is a small bug in the Remix zkSync module. After a successful compilation, the deploy tab will still display the message _`no smart contracts ready for deployment`_.
+As we saw in the _Simple Storage_ section, there is a small bug in the Remix ZKsync module. After a successful compilation, the deploy tab will still display the message _`no smart contracts ready for deployment`_.
 
 This issue arises due to a small bug in the plugin, which requires your smart contracts to be inside a **`contracts` folder**. To resolve this, you can create a new folder named 'contracts' and move your smart contract into it. You can then proceed to compile the contract again, and you should be able to deploy it without any issues.

--- a/courses/solidity/3-fund-me/26-deploying-to-zksync/+page.md
+++ b/courses/solidity/3-fund-me/26-deploying-to-zksync/+page.md
@@ -1,5 +1,5 @@
 ---
-title: deploying FundMe to zkSync
+title: deploying FundMe to ZKsync
 ---
 
 _Follow along with the video_
@@ -8,21 +8,21 @@ _Follow along with the video_
 
 ### Introduction
 
-In this lesson, we'll walk through the steps to deploy the `FundMe` contract to the zkSync testnet.
+In this lesson, we'll walk through the steps to deploy the `FundMe` contract to the ZKsync testnet.
 
-### Adjustments for zkSync
+### Adjustments for ZKsync
 
-First, we'll need the specific the correct **price feed address** for the skSync Sepolia chain, which you can find in the [Chainlink documentation](https://docs.chain.link/data-feeds/price-feeds/addresses?network=zksync&page=1). Each chain has its own unique addresses, and the ETH/USD address for the zkSync Sepolia testnet will differ from the one on Sepolia.
+First, we'll need the specific the correct **price feed address** for the ZKsync Sepolia chain, which you can find in the [Chainlink documentation](https://docs.chain.link/data-feeds/price-feeds/addresses?network=zksync&page=1). Each chain has its own unique addresses, and the ETH/USD address for the ZKsync Sepolia testnet will differ from the one on Sepolia.
 
-Then copy the zkSync Sepolia testnet ETH/USD address and replace the existing address in the `FundMe::getVersion` and `PriceConverter::getPrice` functions:
+Then, copy the ZKsync Sepolia testnet ETH/USD address and replace the existing address in the `FundMe::getVersion` and `PriceConverter::getPrice` functions:
 
-```js
-AggregatorV3Interface priceFeed = AggregatorV3Interface(0xfEefF7c3fB57d18C5C6Cdd71e45D2D0b4F9377bF); // Add ETH/USD zkSync Sepolia address here
+```solidity
+AggregatorV3Interface priceFeed = AggregatorV3Interface(0xfEefF7c3fB57d18C5C6Cdd71e45D2D0b4F9377bF); // Add ETH/USD ZKsync Sepolia address here
 ```
 
-Since the zkSync plugin may not handle libraries well yet, you can copy the library code directly into your contract instead of importing it.
+Since the ZKsync plugin may not handle libraries well yet, you can copy the library code directly into your contract instead of importing it.
 
-It's recommended using the correct version of the Solidity compiler by updating it to version `0.8.24` for zkSync compatibility.
+It's recommended using the correct version of the Solidity compiler by updating it to version `0.8.24` for ZKsync compatibility.
 
 ### Deploying the Contract
 
@@ -30,4 +30,4 @@ In the Environment tab, you can connect your MetaMask wallet and then **deploy a
 
 ### Conclusion
 
-Deploying the `FundMe` contract to the zkSync testnet involves a few key steps. First, adjust the price feed addresses and handle the library code correctly and make sure you're using the correct version of the Solidity compiler. Then you are ready to connect the MetaMask wallet to remix zkSync module and deploy the contract. Finally, you can verify that everything is working as expected by calling the contract functions in the [zkSync block explorer](https://sepolia.explorer.zksync.io/).
+Deploying the `FundMe` contract to the ZKsync testnet involves a few key steps. First, adjust the price feed addresses and handle the library code correctly and make sure you're using the correct version of the Solidity compiler. Then you are ready to connect the MetaMask wallet to Remix ZKsync module and deploy the contract. Finally, you can verify that everything is working as expected by calling the contract functions in the [ZKsync block explorer](https://sepolia.explorer.zksync.io/).

--- a/courses/solidity/3-fund-me/27-recap-congratulations/+page.md
+++ b/courses/solidity/3-fund-me/27-recap-congratulations/+page.md
@@ -14,7 +14,7 @@ We have encountered the special functions `receive`, `fallback`, and `constructo
 
 To save gas, Solidity provides keywords like `constant` and `immutable` for variables that can only be set once:
 
-```js
+```solidity
 uint constant minimumUSD = 50 * 1e18;
 ```
 

--- a/courses/solidity/3-fund-me/5-real-world-price-data/+page.md
+++ b/courses/solidity/3-fund-me/5-real-world-price-data/+page.md
@@ -32,7 +32,7 @@ Chainlink offers ready-made features that can be added to a smart contract. And 
 
 - **Data Feeds**
 - **Verifiable Random Number**
-- **Keepers**
+- **Automation (previously known as "Keepers")**
 - **Functions**
 
 ### Chainlink Data Feeds
@@ -44,13 +44,13 @@ _Chainlink Data Feeds_ are responsible for powering over $50 billion in the DeFi
 They aggregate this data and deliver it to a reference contract, the **price feed contract**, in a single transaction. Each contract will store the pricing details of a specific cryptocurrency
 ::image{src='/solidity/remix/lesson-4/datafeeds/datafeed1.png' style='width: 100%; height: auto;'}
 
-### Chainlink CRF
+### Chainlink VRF
 
 The Chainlink VRF (Verifiable Random Function) provides a solution for generating **provably random numbers**, ensuring true fairness in applications such as NFT randomization, lotteries, and gaming. These numbers are determined off-chain, and they are immune to manipulation.
 
 ::image{src='/solidity/remix/lesson-4/datafeeds/datafeed3.png' style='width: 100%; height: auto;'}
 
-### Chainlink Keepers
+### Chainlink Automation (previously known as "Keepers")
 
 Another great feature is Chainlink's system of _Keepers_. These **nodes** listen for specific events and, upon being triggered, automatically execute the intended actions within the calling contract.
 

--- a/courses/solidity/3-fund-me/6-mid-lesson-recap/+page.md
+++ b/courses/solidity/3-fund-me/6-mid-lesson-recap/+page.md
@@ -12,19 +12,19 @@ From lessons 1 to 5 we've explored the usage of the keyword `payable`, the globa
 
 To enable a function to receive a native blockchain token such as Ethereum, it must be marked as `payable`:
 
-```js
+```solidity
 function deposit() public payable {
- balances[msg.sender] += msg.value;
+    balances[msg.sender] += msg.value;
 }
 ```
 
 If we want a function to fail under certain conditions, we can use the `require` statement. For example, in a bank transfer scenario, we want the operation to fail if the sender does not have enough balance. Here's an example:
 
-```js
+```solidity
 function transfer(address recipient, uint amount) public {
- require(balances[msg.sender] >= amount);
- balances[msg.sender] -= amount;
- balances[recipient] += amount;
+    require(balances[msg.sender] >= amount);
+    balances[msg.sender] -= amount;
+    balances[recipient] += amount;
 }
 ```
 
@@ -41,11 +41,11 @@ Chainlink is a revolutionary technology that enables the integration of external
 
 Consider a smart contract that deals with a commodity like gold. _Chainlink Price Feeds_ can provide real-time gold prices, allowing the smart contract to reflect the current market prices.
 
-```js
+```solidity
 import "@chainlink/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol";
 contract GoldPriceContract {
     AggregatorV3Interface internal priceFeed;
-    //The Chainlink price feed contract address
+    // The Chainlink price feed contract address
     constructor() public {
         priceFeed = AggregatorV3Interface(0x8468b2bDCE073A157E560AA4D9CcF6dB1DB98507);
     }

--- a/courses/solidity/3-fund-me/7-interfaces/+page.md
+++ b/courses/solidity/3-fund-me/7-interfaces/+page.md
@@ -12,7 +12,7 @@ In this part, we'll learn how to **convert** Ethereum (ETH) into Dollars (USD) a
 
 We begin by trying to convert the `msg.value`, which is now specified in ETH, into USD. This process requires fetching the **current USD market price** of Ethereum and using it to convert the `msg.value` amount into USD.
 
-```js
+```solidity
  // Function to get the price of Ethereum in USD
  function getPrice() public {}
  // Function to convert a value based on the price
@@ -39,10 +39,10 @@ An alternative method involves the use of an **Interface**, which defines method
 
 We can test the Interface usage by calling the `version()` function:
 
-```js
- function getVersion() public view returns (uint256) {
+```solidity
+function getVersion() public view returns (uint256) {
     return AggregatorV3Interface(0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419).version();
- }
+}
 ```
 
 > 🗒️ **NOTE**:br

--- a/courses/solidity/3-fund-me/8-ai-help-iii/+page.md
+++ b/courses/solidity/3-fund-me/8-ai-help-iii/+page.md
@@ -59,4 +59,4 @@ By leveraging AI and discussion forums, you can gain a deeper understanding of c
 
 ### 🧑‍💻 Test yourself
 
-1. 📕 Dive deeper into the `getVersion` function by asking AI three more questions about it
+1. 📕 Delve deeper into the `getVersion` function by asking AI three more questions about it

--- a/courses/solidity/3-fund-me/9-importing-from-npm-github/+page.md
+++ b/courses/solidity/3-fund-me/9-importing-from-npm-github/+page.md
@@ -12,7 +12,7 @@ As we delve into smart contract development, **interacting** with external smart
 
 Let's take a look at the `SmartContract` interface as an example:
 
-```js
+```solidity
 interface SmartContract {
     function someFunction() external view returns(uint, uint){};
 }
@@ -26,13 +26,13 @@ Smart Contracts _hosted on GitHub_ can be imported directly into your project. F
 
 Instead of manually copying all its code into your project and then importing it like this:
 
-```js
+```solidity
 import { AggregatorV3Interface } from "./AggregatorV3Interface.sol";
 ```
 
 we can import it more efficiently, as specified in the [Chainlink documentation](https://docs.chain.link/docs/using-chainlink-reference-contracts):
 
-```js
+```solidity
 import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 ```
 
@@ -44,7 +44,7 @@ The `@chainlink/contracts` package, available on NPM, follows **Semantic Version
 
 Remix interprets `@chainlink/contracts` as a reference to the [NPM package](https://www.npmjs.com/package/@chainlink/contracts), and downloads all the necessary code from it.
 
-```js
+```solidity
  pragma solidity ^0.8.18;
  import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
  contract FundMe {}


### PR DESCRIPTION
Fix typos and formatting.

Update "Chainlink Keepers" to "Chainlink Automation (previously known as "Keepers")"
The video lesson is already updated on this name change, but the written lesson has not been updated yet.
https://docs.chain.link/chainlink-automation