### PR TITLE
Written lesson cleanup: ERC20

### DIFF
--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/1-erc20-welcome-to-advanced/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/1-erc20-welcome-to-advanced/+page.md
@@ -13,7 +13,7 @@ If you have any questions or just want to join the discussion, you can do it at 
 ---
 [Discord](https://discord.gg/cyfrin)
 ---
-[GitHub](https://github.com/Cyfrin/path-solidity-developer-2023/discussions)
+[GitHub](https://github.com/Cyfrin/foundry-full-course-cu/discussions)
 ---
 
 See you in the next lesson!

--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/2-erc20-basics/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/2-erc20-basics/+page.md
@@ -25,6 +25,8 @@ If `EIPs` get enough traction to warrant genuine consideration they will often g
 
 New `Improvement Proposals` and `Requests for Comments` are tracked on websites such as [**eips.ethereum.org**](https://eips.ethereum.org/), where you can watch these proposals go through the process real time and be adopted or rejected by the community.
 
+::image{src='/foundry-erc20s/1-erc20-basics/erc20-basics1.PNG' style='width: 100%; height: auto;'}
+
 ### EIP status terms
 
 - **Idea** - An idea that is pre-draft. This is not tracked within the EIP Repository.

--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/2-erc20-basics/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/2-erc20-basics/+page.md
@@ -10,7 +10,7 @@ _Follow along the course with this video._
 
 Welcome back! I hope you're ready to move into some more advanced concepts in Web3. In this section we're going to be diving into `ERC20s`, and how to develop, deploy and test them.
 
-You can find the code associated with section in the [**GitHub repo**](https://github.com/Cyfrin/foundry-full-course-f23) associated with this course, and in the [**section repo specifically**](https://github.com/Cyfrin/foundry-erc20-f23).
+You can find the code associated with section in the [**GitHub repo**](https://github.com/Cyfrin/foundry-full-course-cu) associated with this course, and in the [**section repo specifically**](https://github.com/Cyfrin/foundry-erc20-cu).
 
 Before we rush into creating our own `ERC20 Token`, let's take a moment to learn _what_ an `ERC20` is, what `EIPs` are and where all these acronyms mean.
 
@@ -20,11 +20,22 @@ The Web3 and blockchain ecosystem is fundamentally democratic and open source. A
 
 If `EIPs` get enough traction to warrant genuine consideration they will often generate a `Request for Comments`, in Ethereum these are known as `Ethereum Request for Comments` (`ERCs`).
 
-> ❗ **NOTE** > `EIPs` and `ERCs` are numbered chronologically! `ERC20` is the 20th request for comments that was created.
+> ❗ **NOTE**
+> `EIPs` and `ERCs` are numbered chronologically! `ERC20` is the 20th request for comments that was created.
 
 New `Improvement Proposals` and `Requests for Comments` are tracked on websites such as [**eips.ethereum.org**](https://eips.ethereum.org/), where you can watch these proposals go through the process real time and be adopted or rejected by the community.
 
-::image{src='/foundry-erc20s/1-erc20-basics/erc20-basics1.png' style='width: 100%; height: auto;'}
+### EIP status terms
+
+- **Idea** - An idea that is pre-draft. This is not tracked within the EIP Repository.
+- **Draft** - The first formally tracked stage of an EIP in development. An EIP is merged by an EIP Editor into the EIP repository when properly formatted.
+- **Review** - An EIP Author marks an EIP as ready for and requesting Peer Review.
+- **Last Call** - This is the final review window for an EIP before moving to FINAL. An EIP editor will assign Last Call status and set a review end date (`last-call-deadline`), typically 14 days later. If this period results in necessary normative changes it will revert the EIP to Review.
+- **Final** - This EIP represents the final standard. A Final EIP exists in a state of finality and should only be updated to correct errata and add non-normative clarifications.
+- **Stagnant** - Any EIP in Draft or Review if inactive for a period of 6 months or greater is moved to Stagnant. An EIP may be resurrected from this state by Authors or EIP Editors through moving it back to Draft.
+- **Withdrawn** - The EIP Author(s) have withdrawn the proposed EIP. This state has finality and can no longer be resurrected using this EIP number. If the idea is pursued at a later date it is considered a new proposal.
+- **Living** - A special status for EIPs that are designed to be continually updated and not reach a state of finality. This includes most notably EIP-1.
+
 
 ### ERC20
 
@@ -34,7 +45,7 @@ These tokens essentially exists as records of value within smart contracts on ch
 
 **_Why make an ERC20?_**
 
-There are a few common reasons that someone may choose to launch an `ERC20 token`, but there's very little limit to the possibilities of their application in a digital space. A few common usecases include:
+There are a few common reasons that someone may choose to launch an `ERC20 token`, but there's very little limit to the possibilities of their application in a digital space. A few common use cases include:
 
 - Governance Tokens
 - Securing an underlying network

--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/3-erc20-manual-creation/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/3-erc20-manual-creation/+page.md
@@ -32,7 +32,7 @@ Completing these steps sets up a development environment with some convenient bo
 
 Go ahead and delete our 3 `Counter` examples so we can start with a clean slate.
 
-![Start project with a clean slate](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/2-erc20-manual-creation/erc20-manual-creation1.png?raw=true)
+::image{src='/foundry-erc20s/2-erc20-manual-creation/erc20-manual-creation1.PNG' style='width: 100%; height: auto;'}
 
 I'm going to show you 2 different ways to create our own token, first the hard way and then a much easier way!
 

--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/3-erc20-manual-creation/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/3-erc20-manual-creation/+page.md
@@ -8,15 +8,15 @@ _Follow along the course with this video._
 
 ### ERC20 Manual Creation
 
-Welcome Back! Having covered the basics, let's look at how we can manually create our own ERC20 token. This is going to be one of our fastest lessons yet!
+Welcome back! Having covered the basics, let's look at how we can manually create our own ERC20 token. This is going to be one of our fastest lessons yet!
 
 ### Setting Up Your Environment
 
 Open a terminal in Visual Studio Code and run the following:
 
 ```sh
-mkdir foundry-erc20-f23
-cd foundry-erc20-f23
+mkdir foundry-erc20
+cd foundry-erc20
 code .
 ```
 
@@ -32,24 +32,24 @@ Completing these steps sets up a development environment with some convenient bo
 
 Go ahead and delete our 3 `Counter` examples so we can start with a clean slate.
 
-::image{src='/foundry-erc20s/2-erc20-manual-creation/erc20-manual-creation1.PNG' style='width: 100%; height: auto;'}
+![Start project with a clean slate](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/2-erc20-manual-creation/erc20-manual-creation1.png?raw=true)
 
 I'm going to show you 2 different ways to create our own token, first the hard way and then a much easier way!
 
 You can begin by creating a new token token our `src` directory named `ManualToken.sol`. We can start this contract the same way we've been practicing this whole time (you'll get really familiar with this bit).
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-contract ManualToken {...}
+contract ManualToken {}
 ```
 
 Now, as we covered in the last lesson, all we need to do to make our token compatible is follow the [**ERC20 Token Standard**](https://eips.ethereum.org/EIPS/eip-20). Essentially this means we need to include the required functions/methods for our deployment to follow this standard. Let's add thing functionality then!
 
 Let's start with name, decimals and totalSupply
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
@@ -59,7 +59,7 @@ contract ManualToken {
         return "Manual Token";
     }
 
-    function totalSupply() public pure returns (uint256){
+    function totalSupply() public pure returns (uint256) {
         return 100 ether; // 100000000000000000000
     }
 
@@ -72,9 +72,9 @@ contract ManualToken {
 > ❗ **NOTE**
 > Despite being an optional method, we're including `decimals` here as a point of clarification since we're declaring our total supply as 100 ether. 100 ether = 100 + 18 decimals places.
 
-The next functions required by the ERC20 standard are balanceOf and transfer, so let's apply those now.
+The next functions required by the ERC20 standard are `balanceOf` and `transfer`, so let's apply those now.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
@@ -100,13 +100,13 @@ contract ManualToken {
 
 Hmm, what is this function meant to return exactly? We're probably going to need a mapping to track the balances of each address...
 
-```js
+```solidity
 mapping(address => uint256) private s_balances;
 ```
 
-So now our balanceOf function can return this mapped value based on the address parameter being passed.
+So now our `balanceOf` function can return this mapped value based on the address parameter being passed.
 
-```js
+```solidity
 function balanceOf(address _owner) public pure returns (uint256) {
    return balances[_owner];
 }
@@ -119,13 +119,13 @@ An interesting thing that comes to light from this function is - someone's balan
 
 Our next required function is transfer:
 
-```js
+```solidity
 function transfer(address _to, uint256 _amount) public {
     uint256 previousBalance = balanceOf(msg.sender) + balanceOf(_to);
     s_balance[msg.sender] -= _amount;
     s_balance[_to] += _amount;
 
-    require(balanceOf(msg.sender) + balanceOf(_to) == previousBalances);
+    require(s_balance(msg.sender) + s_balance(_to) == previousBalance);
 }
 
 ```
@@ -136,6 +136,6 @@ So, a basic transfer function could look something like the above, a simple adju
 
 We could absolutely continue going through each of the required functions outlined in the [**ERC20 Token Standard**](https://eips.ethereum.org/EIPS/eip-20) and eventually come out the other side with a compatible contract, but there's an easier way.
 
-In the next lesson we'll investigate an even easier method to spin up a standard ERC20 protocol, with the help of OpenZepplin.
+In the next lesson, we'll investigate an even easier method to spin up a standard ERC20 protocol, with the help of OpenZeppelin.
 
 See you there!

--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/4-erc20-open-zeppelin/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/4-erc20-open-zeppelin/+page.md
@@ -13,13 +13,13 @@ Welcome back! As mentioned in the closing of our last lesson, we could absolutel
 In this section, I'll guide you on using the OpenZeppelin Library to achieve this.
 
 > ❗ **NOTE**
-> OpenZeppelin is renowned for its Smart Contract framework, offering a vast repository of audited contracts readily integratable into your codebase.
+> OpenZeppelin is renowned for its Smart Contract framework, offering a vast repository of audited contracts readily integrable into your codebase.
 
-Access [OpenZeppelin's documentation](https://docs.openzeppelin.com/contracts/4.x/) via their official website. By navigating to [Products -> Contracts](https://www.openzeppelin.com/contracts), you can discover a vast array of ready-to-use contracts.
+Access [OpenZeppelin's documentation](https://docs.openzeppelin.com/contracts/5.x/) via their official website. By navigating to [Products -> Contracts Library](https://www.openzeppelin.com/contracts), you can discover a vast array of ready-to-use contracts.
 
 Additionally, OpenZeppelin offers a contract wizard, streamlining the contract creation process — perfect for tokens, governances, or custom contracts.
 
-::image{src='/foundry-erc20s/3-erc20-open-zeppelin/ERC20-open-zeppelin1.PNG' style='width: 100%; height: auto;'}
+![OpenZeppelin's Contract Wizard](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/3-erc20-open-zeppelin/ERC20-open-zeppelin1.png?raw=true)
 
 Let's leverage OpenZeppelin to create a new ERC20 Token. Create a new file within `src` named `OurToken.sol`. Once that's done, let's install the OpenZeppelin library into our contract.
 
@@ -35,7 +35,7 @@ remappings = ["@openzeppelin=lib/openzeppelin-contracts"]
 
 We can now import and inherit this contract into `OurToken.sol`!
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
@@ -53,14 +53,14 @@ By importing the OpenZeppelin implementation of ERC20 this way, we inherit all t
 
 Now, we should recall that when inheriting from a contract with a constructor, our contract must fulfill the requirements of that constructor. We'll need to define details like a name and symbol for OurToken.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract OurToken is ERC20 {
-    constructor(uint256 initialSupply) ERC20("OurToken", "OT"){
+    constructor(uint256 initialSupply) ERC20("OurToken", "OT") {
         _mint(msg.sender, initialSupply);
     }
 }
@@ -70,7 +70,7 @@ For the purposes of simple examples like this, I like to mint the initialSupply 
 
 As always we can perform a sanity check to assure things are working as expected by running `forge build`.
 
-::image{src='/foundry-erc20s/3-erc20-open-zeppelin/ERC20-open-zeppelin2.PNG' style='width: 100%; height: auto;'}
+![Compiler run successful](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/3-erc20-open-zeppelin/ERC20-open-zeppelin2.png?raw=true)
 
 Nailed it.
 

--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/4-erc20-open-zeppelin/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/4-erc20-open-zeppelin/+page.md
@@ -19,7 +19,7 @@ Access [OpenZeppelin's documentation](https://docs.openzeppelin.com/contracts/5.
 
 Additionally, OpenZeppelin offers a contract wizard, streamlining the contract creation process — perfect for tokens, governances, or custom contracts.
 
-![OpenZeppelin's Contract Wizard](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/3-erc20-open-zeppelin/ERC20-open-zeppelin1.png?raw=true)
+::image{src='/foundry-erc20s/3-erc20-open-zeppelin/erc20-open-zeppelin1.PNG' style='width: 100%; height: auto;'}
 
 Let's leverage OpenZeppelin to create a new ERC20 Token. Create a new file within `src` named `OurToken.sol`. Once that's done, let's install the OpenZeppelin library into our contract.
 
@@ -70,7 +70,7 @@ For the purposes of simple examples like this, I like to mint the initialSupply 
 
 As always we can perform a sanity check to assure things are working as expected by running `forge build`.
 
-![Compiler run successful](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/3-erc20-open-zeppelin/ERC20-open-zeppelin2.png?raw=true)
+::image{src='/foundry-erc20s/3-erc20-open-zeppelin/erc20-open-zeppelin2.PNG' style='width: 100%; height: auto;'}
 
 Nailed it.
 

--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/5-erc20-deploy-script/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/5-erc20-deploy-script/+page.md
@@ -16,7 +16,7 @@ We expect OurToken to behave the same, regardless of the chain it's deployed on,
 
 To begin, we can import Script and OurToken as well as add the skeleton of our run function:
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -24,14 +24,14 @@ pragma solidity ^0.8.18;
 import {Script} from "forge-std/Script.sol";
 import {OurToken} from "../src/OurToken.sol";
 
-contract DeployOurToken is Script returns (OurToken){
+contract DeployOurToken is Script {
     function run() external {}
 }
 ```
 
 We're going to keep this really basic, we just want to deploy OurToken. We know that OurToken requires an initial supply as a constructor parameter, so let's declare that and then deploy our contract.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -55,10 +55,10 @@ contract DeployOurToken is Script {
 
 Our deploy script looks great! To make things a little easier on ourselves when using the CLI to run this script, copy the Makefile from the course GitHub repo and add this to our workspace (I've included it below to copy if needed).
 
-<details>
-<summary>Makefile</summary>
 
-```
+### Makefile
+
+```make
 -include .env
 
 .PHONY: all test clean deploy fund help install snapshot format anvil
@@ -110,16 +110,17 @@ verify:
 
 ```
 
-</details>
 
 ---
 
 Now, by running `make anvil` (open a new terminal once your chain has started!) followed by `make deploy`...
 
-::image{src='/foundry-erc20s/4-erc20-deploy-script/erc20-deploy-script1.png' style='width: 100%; height: auto;'}
+![Script ran
+successfully](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/4-erc20-deploy-script/erc20-deploy-script1.png?raw=true)
+
 
 ### Wrap Up
 
 Woo! Deployment to our anvil chain successful, let's go!
 
-In the next lesson we'll test our contracts with the help of some AI tools and recap everything we've gone over so far. See you there!
+In the next lesson, we'll test our contracts with the help of some AI tools and recap everything we've gone over so far. See you there!

--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/5-erc20-deploy-script/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/5-erc20-deploy-script/+page.md
@@ -115,8 +115,7 @@ verify:
 
 Now, by running `make anvil` (open a new terminal once your chain has started!) followed by `make deploy`...
 
-![Script ran
-successfully](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/4-erc20-deploy-script/erc20-deploy-script1.png?raw=true)
+::image{src='/foundry-erc20s/4-erc20-deploy-script/erc20-deploy-script1.png' style='width: 100%; height: auto;'}
 
 
 ### Wrap Up

--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/6-erc20-ai-tests-and-recap/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/6-erc20-ai-tests-and-recap/+page.md
@@ -8,14 +8,14 @@ _Follow along the course with this video._
 
 ### AI Tests and Recap
 
-Almost done, you're doing great! The last thing we want to assure is that we're always testing any code we write before it's deployed to a production envirvonment. Fortunately, AI is becoming more and more capable each day at being able to assist us with some basic tests.
+Almost done, you're doing great! The last thing we want to assure is that we're always testing any code we write before it's deployed to a production environment. Fortunately, AI is becoming more and more capable each day at being able to assist us with some basic tests.
 
 > ❗ **IMPORTANT**
 > I want you to use AI to jumpstart your learning, don't use it to substitute learning. It can be really easy to fall back on having answers provided to us. I strongly encourage you to use AI consciously and with the intent of supporting your efforts, not doing the work for you.
 
 We're going to write a couple tests together, then see if an AI can help us with some others. Go ahead and create a new file within our `test` folder named `OurTokenTest.t.sol`.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -31,7 +31,7 @@ contract OurTokenTest is Test {
 
 With this boiler plate set up in `OurTokenTest.t.sol` we can begin by declaring `OurToken` and `Deployer` variables and deploying these. We'll also need to create some accounts/addresses for our tests.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -56,7 +56,7 @@ contract OurTokenTest is Test {
 
 The last thing we need in our `setUp` function is to assure one of our accounts is given some `OurToken` to play with. We wrote `OurToken` to mint it's `INITIAL_SUPPLY` to the `msg.sender`. Let's have our `msg.sender` contract transfer `100 ether` worth of `OurToken` to Bob.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -84,9 +84,9 @@ contract OurTokenTest is Test {
 }
 ```
 
-Bam! With this we're ready to start writing our first test. We'll start with a simple one, let's assure that the STARTING_BALANCE was in fact sent to Bob.
+Bam! With this we're ready to start writing our first test. We'll start with a simple one, let's assure that the `STARTING_BALANCE` was in fact sent to Bob.
 
-```js
+```solidity
 function testBobBalance() public view {
     assertEq(STARTING_BALANCE, ourToken.balanceOf(bob));
 }
@@ -98,7 +98,7 @@ Let's run it!
 forge test --mt testBobBalance
 ```
 
-::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap1.png' style='width: 100%; height: auto;'}
+![Compiler run successful](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap1.png?raw=true)
 
 Easy pass. Let's write a couple more tests and then we'll see what AI can do to help us.
 
@@ -106,29 +106,29 @@ Easy pass. Let's write a couple more tests and then we'll see what AI can do to 
 
 Next, let's test some approvals. The ERC20 standard contains an important function, `transferFrom`. It is often the case that a smart contract protocol may need to transfer tokens _on behalf_ of a user the way this access is controlled is through the `transferFrom` function.
 
-::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap2.png' style='width: 100%; height: auto;'}
+![transferFrom description](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap2.png?raw=true)
 
 In summary, an address needs to be approved by another in order to transfer tokens on their behalf, otherwise the transaction should revert with an error.
 
 Approvals, naturally, are handled through the `approve` and allowance functionality within the ERC20 standard.
 
-::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap3.png' style='width: 100%; height: auto;'}
+![approve description](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap3.png?raw=true)
 
 Through these methods a user is able to approve another address to spend, or otherwise interact with, a limited (or often unlimited) number of tokens.
 
 The security risks associated with this are pretty clear, which is why we've seen services like Etherscan's Token Approval Checker pop up. These allow you to see at a glance which addresses possess approvals for tokens in your wallet.
 
-::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap4.png' style='width: 100%; height: auto;'}
+![Revoke permissions button](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap4.png?raw=true)
 
 While it costs a little gas, it's good practice to regularly assess your approvals and revoke them when no longer applicable or appropriate.
 
 With all this context in mind, let's look at what a test for OurToken allowances looks like.
 
-```js
+```solidity
 function testAllowancesWork() public {
     uint256 initialAllowance = 1000;
 
-    //Bob approves Alice to spend 1000 tokens.
+    // Bob approves Alice to spend 1000 tokens.
     vm.prank(bob);
     ourToken.approve(alice, initialAllowance);
 
@@ -141,14 +141,14 @@ function testAllowancesWork() public {
 
 Here, we're declaring an initial balance and pranking Bob to call approve on `OurToken`. This is allowing `Alice` to transfer up to `1000 OurTokens`.
 
-We then declare a transfer amount, and prank `Alice` as we call `transferFrom`, transfering tokens from `Bob`'s address to `Alice`'s.
+We then declare a transfer amount, and prank `Alice` as we call `transferFrom`, transferring tokens from `Bob`'s address to `Alice`'s.
 
 > ❗ **NOTE**
 > The `transfer` function won't work here as the `from` address defaults to msg.sender!
 
 All we need now is our assert statements.
 
-```js
+```solidity
 assertEq(outToken.balanceOf(alice), transferAmount);
 assertEq(ourToken.balanceOf(bob), STARTING_BALANCE - transferAmount);
 ```
@@ -159,11 +159,11 @@ Let's run the test!
 forge test --mt testAllowancesWork
 ```
 
-::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap5.png' style='width: 100%; height: auto;'}
+![Tests pass](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap5.png?raw=true)
 
 Nice, another pass! However, if we run `forge coverage` ...
 
-::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap6.png' style='width: 100%; height: auto;'}
+![Test coverage](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap6.png?raw=true)
 
 Abysmal. We have a long way to go!
 
@@ -173,10 +173,9 @@ AI can be a little hit and miss when it comes to accuracy and reliability, but o
 
 OpenAI has a very capable free tier for ChatGPT available [**here**](https://chatgpt.com). Navigate to the platform and create an account if needed.
 
-<details>
-<summary>AI Prompt</summary>
+### AI Prompt
 
-```
+````text
 Here is my solidity ERC20 token.
 
 ```
@@ -239,18 +238,17 @@ Can you write the rest of the tests? Please include tests for:
 - Allowances
 - transfers
 - anything else that might be important
-```
+````
 
-</details>
 
 ---
 
 > ❗ **NOTE**
 > Your specific response will differ from mine, I encourage you to try using an AI tool like ChatGPT to generate a few tests of your own. I've included my AI response below, generated by GPT4o May 31, 2024.
 
-<details>
-<summary>Example AI Response</summary>
+### Example AI Response
 
+````text
 Sure, here are the rest of the tests for your ERC20 token, including tests for allowances, transfers, and a few other important functionalities.
 
 ```solidity
@@ -357,8 +355,7 @@ contract OurTokenTest is StdCheats, Test {
 - **testFailApproveExceedsBalance**: Ensures that approving more than the balance fails.
 - **testTransferEvent**: Verifies that the `Transfer` event is emitted correctly during a transfer.
 - **testApprovalEvent**: Verifies that the `Approval` event is emitted correctly during an approval.
-
-</details>
+````
 
 ---
 
@@ -378,10 +375,9 @@ See you soon!
 
 ---
 
-<details>
-<summary>AI Tests</summary>
+### AI Tests
 
-```js
+```solidity
 function testTransfer() public {
     uint256 amount = 1000 * 10 ** 18; // Example amount
     vm.prank(msg.sender);
@@ -416,5 +412,3 @@ function testFailApproveExceedsBalance() public {
     ourToken.approve(user1, amount); // This should fail
 }
 ```
-
-</details>

--- a/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/6-erc20-ai-tests-and-recap/+page.md
+++ b/courses/advanced-foundry/1-How-to-create-an-erc20-crypto-currency/6-erc20-ai-tests-and-recap/+page.md
@@ -98,7 +98,7 @@ Let's run it!
 forge test --mt testBobBalance
 ```
 
-![Compiler run successful](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap1.png?raw=true)
+::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap1.png' style='width: 100%; height: auto;'}
 
 Easy pass. Let's write a couple more tests and then we'll see what AI can do to help us.
 
@@ -106,19 +106,19 @@ Easy pass. Let's write a couple more tests and then we'll see what AI can do to 
 
 Next, let's test some approvals. The ERC20 standard contains an important function, `transferFrom`. It is often the case that a smart contract protocol may need to transfer tokens _on behalf_ of a user the way this access is controlled is through the `transferFrom` function.
 
-![transferFrom description](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap2.png?raw=true)
+::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap2.png' style='width: 100%; height: auto;'}
 
 In summary, an address needs to be approved by another in order to transfer tokens on their behalf, otherwise the transaction should revert with an error.
 
 Approvals, naturally, are handled through the `approve` and allowance functionality within the ERC20 standard.
 
-![approve description](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap3.png?raw=true)
+::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap3.png' style='width: 100%; height: auto;'}
 
 Through these methods a user is able to approve another address to spend, or otherwise interact with, a limited (or often unlimited) number of tokens.
 
 The security risks associated with this are pretty clear, which is why we've seen services like Etherscan's Token Approval Checker pop up. These allow you to see at a glance which addresses possess approvals for tokens in your wallet.
 
-![Revoke permissions button](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap4.png?raw=true)
+::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap4.png' style='width: 100%; height: auto;'}
 
 While it costs a little gas, it's good practice to regularly assess your approvals and revoke them when no longer applicable or appropriate.
 
@@ -159,11 +159,11 @@ Let's run the test!
 forge test --mt testAllowancesWork
 ```
 
-![Tests pass](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap5.png?raw=true)
+::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap5.png' style='width: 100%; height: auto;'}
 
 Nice, another pass! However, if we run `forge coverage` ...
 
-![Test coverage](https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap6.png?raw=true)
+::image{src='/foundry-erc20s/5-erc20-ai-tests-and-recap/erc20-ai-tests-and-recap6.png' style='width: 100%; height: auto;'}
 
 Abysmal. We have a long way to go!
 


### PR DESCRIPTION
Fix formatting, demo code, and images
- commit 47cc89e: For this particular image, it is text. I used markdown instead of linking to the image.
https://github.com/Cyfrin/Updraft/blob/main/static/foundry-erc20s/1-erc20-basics/erc20-basics1.png?raw=true
Other images are fixed with the images' new location.