### PR TITLE
Advanced Foundry, DeFi Stablecoin: Add missing visibility specifier

### DIFF
--- a/courses/advanced-foundry/3-develop-defi-protocol/12-defi-deposit-and-mint/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/12-defi-deposit-and-mint/+page.md
@@ -10,8 +10,7 @@ _Follow along the course with this video._
 
 Our current DSCEngine.sol for reference:
 
-<details>
-<summary>DSCEngine.sol</summary>
+DSCEngine.sol
 
 ```js
 // Layout of Contract:
@@ -235,9 +234,6 @@ contract DSCEngine is ReentrancyGuard {
 }
 ```
 
-</details>
-
-
 Welcome back! I'm excited to keep going. So far our DSCEngine.sol has quite a bit of functionality already. We've the ability to mint DSC, we can deposit collateral, check account information and more.
 
 The next thing I want to tackle is sort of the main function we'd expect in this protocol, depositCollateralAndMintDsc. This function should serve as a combination of the last two we wrote which allows users to deposit and mint in a single transaction.
@@ -262,7 +258,7 @@ Because this is one of our main functions, we're absolutely going to add some NA
  * @param amountDscToMint: The amount of DecentralizedStableCoin to mint
  * @notice: This function will deposit your collateral and mint DSC in one transaction
  */
-function depositCollateralAndMintDsc(address tokenCollateralAddress, uint256 amountCollateral, uint256 amountDscToMint){
+function depositCollateralAndMintDsc(address tokenCollateralAddress, uint256 amountCollateral, uint256 amountDscToMint) external {
     depositCollateral(tokenCollateralAddress, amountCollateral);
     mintDsc(amountDscToMint);
 }

--- a/courses/advanced-foundry/3-develop-defi-protocol/12-defi-deposit-and-mint/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/12-defi-deposit-and-mint/+page.md
@@ -10,7 +10,8 @@ _Follow along the course with this video._
 
 Our current DSCEngine.sol for reference:
 
-DSCEngine.sol
+<details>
+<summary>DSCEngine.sol</summary>
 
 ```js
 // Layout of Contract:
@@ -233,6 +234,9 @@ contract DSCEngine is ReentrancyGuard {
     function getHealthFactor() external view {}
 }
 ```
+
+</details>
+
 
 Welcome back! I'm excited to keep going. So far our DSCEngine.sol has quite a bit of functionality already. We've the ability to mint DSC, we can deposit collateral, check account information and more.
 

--- a/courses/advanced-foundry/3-develop-defi-protocol/15-defi-liquidation-refactor/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/15-defi-liquidation-refactor/+page.md
@@ -207,7 +207,7 @@ contract DSCEngine is ReentrancyGuard {
         }
         uint256 tokenAmountFromDebtCovered = getTokenAmountFromUsd(collateral, debtToCover);
 
-        uint256 bonusCollateral = (tokeAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
+        uint256 bonusCollateral = (tokenAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
 
         uint256 totalCollateralRedeemed = tokenAmountFromDebtCovered + bonusCollateral;
     }
@@ -340,7 +340,7 @@ We'll add this new internal function under our `Private & Internal View Function
 //   Private & Internal View Functions   //
 ///////////////////////////////////////////
 
-function _redeemCollateral(address tokenCollateralAddress, uint256 amountCollateral, address from, address to){
+function _redeemCollateral(address tokenCollateralAddress, uint256 amountCollateral, address from, address to) private {
     s_collateralDeposited[from][tokenCollateralAddress] -= amountCollateral;
     emit CollateralRedeemed(msg.sender, tokenCollateralAddress, amountCollateral);
 
@@ -396,7 +396,7 @@ function liquidate(address collateral, address user, uint256 debtToCover) extern
     }
     uint256 tokenAmountFromDebtCovered = getTokenAmountFromUsd(collateral, debtToCover);
 
-    uint256 bonusCollateral = (tokeAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
+    uint256 bonusCollateral = (tokenAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
 
     uint256 totalCollateralRedeemed = tokenAmountFromDebtCovered + bonusCollateral;
 
@@ -434,7 +434,7 @@ function liquidate(address collateral, address user, uint256 debtToCover) extern
     }
     uint256 tokenAmountFromDebtCovered = getTokenAmountFromUsd(collateral, debtToCover);
 
-    uint256 bonusCollateral = (tokeAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
+    uint256 bonusCollateral = (tokenAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
 
     uint256 totalCollateralRedeemed = tokenAmountFromDebtCovered + bonusCollateral;
 
@@ -475,7 +475,7 @@ function liquidate(address collateral, address user, uint256 debtToCover) extern
     }
     uint256 tokenAmountFromDebtCovered = getTokenAmountFromUsd(collateral, debtToCover);
 
-    uint256 bonusCollateral = (tokeAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
+    uint256 bonusCollateral = (tokenAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
 
     uint256 totalCollateralRedeemed = tokenAmountFromDebtCovered + bonusCollateral;
 


### PR DESCRIPTION
## commit [2a32a87](https://github.com/Cyfrin/Updraft/pull/241/commits/2a32a87432fcc45f1ad6f46a81a6a41f26548a95)
In the video lesson, the `depositCollateralAndMintDsc()` function is `external`.
In the written lesson, there is no visibility specifier.
This PR adds `external` to the written lesson.

Screenshot showing video lesson and `external`:
![Screenshot 2024-10-22 at 10 57 57 AM](https://github.com/user-attachments/assets/95ff78e8-1017-4ed1-83dd-bbfe40422879)

## commit [b4c48ba](https://github.com/Cyfrin/Updraft/pull/241/commits/b4c48ba608459dcbc4bcf49aaf90e8da6615c2c5)
In the video lesson, the `_redeemCollateral()` function is `private`.
In the written lesson, there is no visibility specifier.
This PR adds `private` to the written lesson,
and fix a typo in the variable name `tokeAmountFromDebtCovered` to `tokenAmountFromDebtCovered` (missing `n`).
![Screenshot 2024-10-24 at 12 45 19 PM](https://github.com/user-attachments/assets/5caef11a-1db5-4350-9922-7e35a2c61579)
