### PR TITLE
Advanced Foundry, DeFi Stablecoin: Fix typos

### DIFF
--- a/courses/advanced-foundry/3-develop-defi-protocol/13-defi-redeem-collateral/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/13-defi-redeem-collateral/+page.md
@@ -284,7 +284,7 @@ event CollateralDeposited(address indexed user, address indexed token, uint256 i
 event CollateralRedeemed(address indexed user, address indexed token, uint256 indexed amount);
 ```
 
-At this point in our function, we'll want to transfer the redeemed tokens to the user, but we're caught in a trap of sorts. Part of our requirements for this function is that the user's `Health Factor` mustn't be broken after the transfer as occured. In situations like these, you may see the `CEI (Checks, Effects, Interactions)` pattern broken sometimes. A protocol _could_ call a function prior to the transfer to calculate changes and determine if the `Health Factor` is broken, before a transfer occurs, but this is often quite gas intensive. For this reason protocols will often sacrifice `CEI` for efficiency.
+At this point in our function, we'll want to transfer the redeemed tokens to the user, but we're caught in a trap of sorts. Part of our requirements for this function is that the user's `Health Factor` mustn't be broken after the transfer as occurred. In situations like these, you may see the `CEI (Checks, Effects, Interactions)` pattern broken sometimes. A protocol _could_ call a function prior to the transfer to calculate changes and determine if the `Health Factor` is broken, before a transfer occurs, but this is often quite gas intensive. For this reason protocols will often sacrifice `CEI` for efficiency.
 
 ```js
 function redeemCollateral(address tokenCollateralAddress, uint256 amountCollateral) public moreThanZero(amountCollateral) nonReentrant{

--- a/courses/advanced-foundry/3-develop-defi-protocol/14-defi-liquidation-setup/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/14-defi-liquidation-setup/+page.md
@@ -399,7 +399,7 @@ function liquidate(address collateral, address user, uint256 debtToCover) extern
 
     uint256 tokenAmountFromDebtCovered = getTokenAmountFromUsd(collateral, debtToCover);
 
-    uint256 bonusCollateral = (tokeAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
+    uint256 bonusCollateral = (tokenAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
 }
 ```
 
@@ -424,7 +424,7 @@ function liquidate(address collateral, address user, uint256 debtToCover) extern
 
     uint256 tokenAmountFromDebtCovered = getTokenAmountFromUsd(collateral, debtToCover);
 
-    uint256 bonusCollateral = (tokeAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
+    uint256 bonusCollateral = (tokenAmountFromDebtCovered * LIQUIDATION_BONUS) / LIQUIDATION_PRECISION;
 
     uint256 totalCollateralRedeemed = tokenAmountFromDebtCovered + bonusCollateral;
 }

--- a/courses/advanced-foundry/3-develop-defi-protocol/16-defi-leveling-up-testing/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/16-defi-leveling-up-testing/+page.md
@@ -137,7 +137,7 @@ contract SmallSol {
 }
 ```
 
-In the above simple contract example, the obvious path is returning the `result of a + 1`. Another less obvious path would be this function `f` reverting due to overflow. Symbolic Execution, through it's mathetmatical modelling, would traverse all possible paths, looking for criteria that break our invariant. These paths might be represented something like this:
+In the above simple contract example, the obvious path is returning the `result of a + 1`. Another less obvious path would be this function `f` reverting due to overflow. Symbolic Execution, through it's mathematical modelling, would traverse all possible paths, looking for criteria that break our invariant. These paths might be represented something like this:
 
 **Path 1:** `assert(a not 2**256 - 1); a:= a+1; return a;`
 

--- a/courses/advanced-foundry/3-develop-defi-protocol/19-defi-handler-deposit-collateral/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/19-defi-handler-deposit-collateral/+page.md
@@ -8,7 +8,7 @@ _Follow along the course with this video._
 
 ### Handler - Redeeming Collateral
 
-Ok! In this lesson we're going to adjust the code in our Invariants.t.sol such that our tests are more focused by being routed through a handler contract. In so doing, our tests will have a more sensible order of functions to call and more contexually relavent random data.
+Ok! In this lesson we're going to adjust the code in our Invariants.t.sol such that our tests are more focused by being routed through a handler contract. In so doing, our tests will have a more sensible order of functions to call and more contextually relevant random data.
 
 We'll start by creating the Handler.t.sol contract.
 

--- a/courses/advanced-foundry/3-develop-defi-protocol/23-defi-handler-price-feed/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/23-defi-handler-price-feed/+page.md
@@ -10,7 +10,7 @@ _Follow along the course with this video._
 
 Our handler looks great at this point, but it doesn't reflect everything. Another powerful feature of this methodology is that we're able to leverage our handler to guide not only our target contract, but any contract we want!
 
-Take price feeds for example. These are external references that our protcol depends upon to function properly. We can use our handler to more realistically emulate how price feeds would behave in real-world scenarios.
+Take price feeds for example. These are external references that our protocol depends upon to function properly. We can use our handler to more realistically emulate how price feeds would behave in real-world scenarios.
 
 Our project should already contain a MockV3Aggregator within the mocks folder, so let's begin by importing it into Handler.t.sol. This file mimics the behaviour of a price feed.
 

--- a/courses/advanced-foundry/3-develop-defi-protocol/26-defi-recap/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/26-defi-recap/+page.md
@@ -29,7 +29,7 @@ We have 3 lessons remaining in this section, and they'll be a breeze compared to
 
 See you soon!
 
-### Excercises
+### Exercises
 
 [**Arbitrum NFT Challenge**](https://arbiscan.io/address/0x3DbBF2F9AcFB9Aac8E0b31563dd75a2D69148D64#code)
 

--- a/courses/advanced-foundry/3-develop-defi-protocol/6-defi-deposit-collateral/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/6-defi-deposit-collateral/+page.md
@@ -262,7 +262,7 @@ Now we can finally add the deposited collateral to our user's balance within our
  * @param amountCollateral: The amount of collateral you're depositing
  */
 function depositCollateral(address tokenCollateralAddress, uint256 amountCollateral) external moreThanZero(amountCollateral) isAllowedToken(tokenCollateralAddress) nonReentrant{
-    s_collateralDeposited[msg.sender][tokenCollateralAddress] =+ amountCollateral;
+    s_collateralDeposited[msg.sender][tokenCollateralAddress] += amountCollateral;
 }
 ```
 
@@ -286,7 +286,7 @@ event CollateralDeposited(address indexed user, address indexed token, uint256 i
  * @param amountCollateral: The amount of collateral you're depositing
  */
 function depositCollateral(address tokenCollateralAddress, uint256 amountCollateral) external moreThanZero(amountCollateral) isAllowedToken(tokenCollateralAddress) nonReentrant{
-    s_collateralDeposited[msg.sender][tokenCollateralAddress] =+ amountCollateral;
+    s_collateralDeposited[msg.sender][tokenCollateralAddress] += amountCollateral;
     emit CollateralDeposited(msg.sender, tokenCollateralAddress, amountCollateral);
 }
 ```
@@ -313,7 +313,7 @@ import {IERC20} from "@openzeppelin/contracts/tokens/ERC20/IERC20.sol";
  * @param amountCollateral: The amount of collateral you're depositing
  */
 function depositCollateral(address tokenCollateralAddress, uint256 amountCollateral) external moreThanZero(amountCollateral) isAllowedToken(tokenCollateralAddress) nonReentrant{
-    s_collateralDeposited[msg.sender][tokenCollateralAddress] =+ amountCollateral;
+    s_collateralDeposited[msg.sender][tokenCollateralAddress] += amountCollateral;
     emit CollateralDeposited(msg.sender, tokenCollateralAddress, amountCollateral);
 
     IERC20(tokenCollateralAddress).transferFrom(msg.sender, address(this), amountCollateral);


### PR DESCRIPTION
Fix typos.

For typos that involves demo code, there are:
- `tokeAmountFromDebtCovered` should be `tokenAmountFromDebtCovered`
- `=+` should be `+=`