### PR TITLE
Advanced Foundry, Airdrop and Signatures: Fix default Anvil key

### DIFF
--- a/courses/advanced-foundry/4-merkle-airdrop/20-creating-a-signature/+page.md
+++ b/courses/advanced-foundry/4-merkle-airdrop/20-creating-a-signature/+page.md
@@ -19,7 +19,7 @@ Copy the [Makefile content](https://github.com/Cyfrin/foundry-merkle-airdrop-cu/
 To obtain the data for signing, use the `getMessageHash` function on the `MerkleAirdrop` contract. This function requires an account address, a `uint256` amount, and the Anvil node URL (`http://localhost:8545`).
 
 ```bash
-cast call 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 "getMessageHash(address,uint256)" 0xf39Fd6e51aad88F6f4ce6aB88272ffFb92266 25000000000000000000 --rpc-url http://localhost:8545
+cast call 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 "getMessageHash(address,uint256)" 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 25000000000000000000 --rpc-url http://localhost:8545
 0x184e30c4b19f5e304a893524210d50346dad61c461e79155b910e73fd856dc72
 ```
 


### PR DESCRIPTION
Change from invalid address from 
0xf39Fd6e51aad88F6f4ce6aB88272ffFb92266 to valid address from Anvil 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

```
invalid from written lesson:
0xf39Fd6e51aad88F6f4ce6aB88272ffFb92266

valid from Anvil and from video lesson:
0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
```

<img width="1643" alt="Screenshot 2024-11-30 at 2 55 08 AM" src="https://github.com/user-attachments/assets/b905643b-f016-48d3-8a85-7ad86f90d7c4">


Maybe some regex removed those characters in the middle of the address in the written lesson like that base64 hash from the NFT lesson?

