### PR TITLE
Advanced Foundry, Airdrop and Signatures: Fix cast call's parameter

### DIFF
--- a/courses/advanced-foundry/4-merkle-airdrop/22-executing-the-anvil-script/+page.md
+++ b/courses/advanced-foundry/4-merkle-airdrop/22-executing-the-anvil-script/+page.md
@@ -14,10 +14,10 @@ forge script script/Interact.s.sol:ClaimAirdrop --rpc-url http://localhost:8545 
 
 Here we are utilizing the **second Anvil key** to claim tokens and covering gas fees as a third-party address. The airdropped tokens will be then sent to the first Anvil address CLAIMING_ADDRESS we hardcoded in our script.
 
-After that, we can verify if the first address has in fact received the airdrop:
+After that, we can verify if the first Anvil address, `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`, has in fact received the airdrop:
 
 ```bash
-cast call 0x5FbDB2315678afecb367f032d93F642f64180aa3 "balanceOf(address)"
+cast call 0x5FbDB2315678afecb367f032d93F642f64180aa3 "balanceOf(address)" 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 ```
 
 cast will respond with the `0x000000000000000000000000000000000000000000000015af1d78b58c40000` hex number, which we can convert into decimal format with:


### PR DESCRIPTION
The written lesson left out the parameter, but the video lesson has it.
The parameter is the 1st default Anvil public key.
Without the parameter, `cast call` fails with an error message saying the function expects 1 parameter.

<img width="1343" alt="Screenshot 2024-12-11 at 4 53 14 PM" src="https://github.com/user-attachments/assets/73fcfe05-e86c-4494-9bbb-1de3b62ff5e7" />
