### PR TITLE
docs: fix storage slot number and uint128 byte size calculations

### DIFF
--- a/courses/foundry/2-foundry-fund-me/18-introduction-to-storage-optimization/+page.md
+++ b/courses/foundry/2-foundry-fund-me/18-introduction-to-storage-optimization/+page.md
@@ -42,7 +42,7 @@ uint64 var3 = 0;
 
 How are these stored?
 
-In `slot 0` we have `var1`, in `slot 1` we have `var2`, and in `slot 3` we have `var 3`. Because `var 3` only used 8 bytes, we have 24 bytes left in that slot. Let's try another one:
+In `slot 0` we have `var1`, in `slot 1` we have `var2`, and in `slot 2` we have `var 3`. Because `var 3` only used 8 bytes, we have 24 bytes left in that slot. Let's try another one:
 
 ```solidity
 uint64 var1 = 1337;

--- a/courses/foundry/2-foundry-fund-me/18-introduction-to-storage-optimization/+page.md
+++ b/courses/foundry/2-foundry-fund-me/18-introduction-to-storage-optimization/+page.md
@@ -70,7 +70,7 @@ Let's structure them better this time:
 `slot 1`
 - var5 8 bytes (8 total)
 - user1 20 bytes (28 total)
-- var6 has 8 bytes, it would generate a total of 36 bytes, we have a max of 32 so we start the next slot
+- var6 has 16 bytes, it would generate a total of 44 bytes, we have a max of 32 so we start the next slot
 
 `slot2`
 - var6 16 byes (16 total)


### PR DESCRIPTION

- Fix incorrect slot number (3 -> 2) in basic variables example
- Fix uint128 byte size calculation (8 -> 16) in complex example

#295 