### PR TITLE
Advanced Foundry, Upgradeable Smart Contracts: Pin version in openzeppelin-contracts-upgradeable and initialize proxy in demo code

### DIFF
--- a/courses/advanced-foundry/5-upgradeable-smart-contracts/4-uups/+page.md
+++ b/courses/advanced-foundry/5-upgradeable-smart-contracts/4-uups/+page.md
@@ -86,7 +86,7 @@ contract BoxV2 {
 In order to implement the UUPS functionality, we're going to leverage an OpenZeppelin library. This one is actually different from the OpenZeppelin/Contracts we're used to and is tailored specifically for upgradeability. Let's install this library.
 
 ```bash
-forge install OpenZeppelin/openzeppelin-contracts-upgradeable --no-commit
+forge install OpenZeppelin/openzeppelin-contracts-upgradeable@v4.9.6 --no-commit
 ```
 
 Once installed we can add our remappings to our `foundry.toml`

--- a/courses/advanced-foundry/5-upgradeable-smart-contracts/5-uups-deploy/+page.md
+++ b/courses/advanced-foundry/5-upgradeable-smart-contracts/5-uups-deploy/+page.md
@@ -96,6 +96,7 @@ contract DeployBox is Script {
         vm.startBroadcast();
         BoxV1 box = new BoxV1(); // Implementation
         ERC1967Proxy proxy = new ERC1967Proxy(address(box), "");
+        BoxV1(address(proxy)).initialize();
         vm.stopBroadcast();
         return address(proxy);
     }


### PR DESCRIPTION
Pin to latest v4 because in openzeppelin-contracts-upgradeable v5, there are 2 changes that result in the tutorial's demo code to not work and returns error:
1. `__Ownable_init()` takes a parameter in v5
2. `upgradeTo()` deprecated in v5

(Perhaps a note for instructors when they update the lesson in the future 😀)

Latest v4 is v4.9.6
https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/tags

----
Added a line that's missing in written lesson's demo code, so that `forge test` works: Initialize proxy.
The line is in the demo code's GitHub repository but not in the demo code in the written lesson.
https://github.com/Cyfrin/foundry-upgrades-cu/blob/main/script/DeployBox.s.sol#L18

<img width="757" alt="Screenshot 2025-01-04 at 2 53 34 PM" src="https://github.com/user-attachments/assets/c289ef68-8253-4214-a9ed-c3055b98ea9e" />

