### PR TITLE
Fix invalid markdown files

### DIFF
--- a/courses/formal-verification/1-horse-store/69-huff-constructor/+page.md
+++ b/courses/formal-verification/1-horse-store/69-huff-constructor/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Huff Constructor
+---
 
 _Follow along with this video:_
 

--- a/courses/formal-verification/1-horse-store/70-huff-yul-and-solidity-gas-comparisons/+page.md
+++ b/courses/formal-verification/1-horse-store/70-huff-yul-and-solidity-gas-comparisons/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Huff/Yul/Solidity Gas Comparison
+---
 
 _Follow along with this video:_
 

--- a/courses/formal-verification/1-horse-store/71-section-1-horsestore-recap/+page.md
+++ b/courses/formal-verification/1-horse-store/71-section-1-horsestore-recap/+page.md
@@ -1,5 +1,7 @@
 ---
 title: Section 1 HorseStore Recap
+---
+
 _Follow along with this video:_
 ---
 

--- a/courses/foundry/2-foundry-fund-me/21-automate-your-smart-contracts-actions-makefile/+page.md
+++ b/courses/foundry/2-foundry-fund-me/21-automate-your-smart-contracts-actions-makefile/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Automate your smart contracts actions - Makefile
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/10-the-modulo-operation/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/10-the-modulo-operation/+page.md
@@ -1,5 +1,6 @@
 ---
 title: The modulo operation
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/11-implementing the lottery state-enum/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/11-implementing the lottery state-enum/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Implementing the lottery state - Enum
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/12-lottery-restart-resetting-an-array/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/12-lottery-restart-resetting-an-array/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Lottery restart - Resetting an Array
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/13-important-note-on-learning-by-building/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/13-important-note-on-learning-by-building/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Important - Note on learning by building
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/14-the-cei-method-checks-efects-interactions/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/14-the-cei-method-checks-efects-interactions/+page.md
@@ -1,5 +1,6 @@
 ---
 title: The CEI method - Checks, Effects, Interactions
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/15-introduction-to-chainlink-automation/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/15-introduction-to-chainlink-automation/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to Chainlink Automation
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/16-implementing-chainlink-automation/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/16-implementing-chainlink-automation/+page.md
@@ -1,6 +1,6 @@
 ---
 title: Implementing Chainlink Automation
-
+---
 _Follow along with this video:_
 
 ---

--- a/courses/foundry/4-smart-contract-lottery/18-mid-section-recap/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/18-mid-section-recap/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Mid section recap
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/19-tests-and-deploy-the-lotterys-smart-contract-pt1/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/19-tests-and-deploy-the-lotterys-smart-contract-pt1/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Tests and deploy the lotteries smart contract pt.2
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/2-smart-contract-lottery-project-setup/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/2-smart-contract-lottery-project-setup/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Smart Contract Lottery - Project setup
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/21-deploy-a-mock-chainlink-vrf/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/21-deploy-a-mock-chainlink-vrf/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Deploy a mock Chainlink VRF
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/22-tests-and-deploy-the-lotterys-smart-contract-p2/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/22-tests-and-deploy-the-lotterys-smart-contract-p2/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Tests and deploy the lottery smart contract pt.1
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/23-setup-the-tests/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/23-setup-the-tests/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Setup the tests
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/25-adding-more-tests/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/25-adding-more-tests/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Adding more tests
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/26-testing-events/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/26-testing-events/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Testing events
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/27-using-vm.roll-and-vm.wrap/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/27-using-vm.roll-and-vm.wrap/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Using vm.roll and vm.wrap
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/28-subscribing-to-events/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/28-subscribing-to-events/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Subscribing to events
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/29-creating-the-subscription-ui/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/29-creating-the-subscription-ui/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Creating the subscription UI
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/3-solidity-style-guide/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/3-solidity-style-guide/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Solidity style guide
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/30-fund-subscription/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/30-fund-subscription/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Fund subscription
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/31-adding-a-consumer/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/31-adding-a-consumer/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Adding a consumer
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/34-testing-and-refactoring-the-performupkeep/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/34-testing-and-refactoring-the-performupkeep/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Testing and refactoring the performUpkeep
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/35-refactoring-events-data/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/35-refactoring-events-data/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Refactoring events data
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/36-intro-to-fuzz-testing/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/36-intro-to-fuzz-testing/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Intro to fuzz testing
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/37-one-big-test/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/37-one-big-test/+page.md
@@ -1,5 +1,6 @@
 ---
 title: One Big Test
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/38-forked-test-environment-and-dynamic-private-keys/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/38-forked-test-environment-and-dynamic-private-keys/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Forked test environment and dynamic private keys
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/39-creating-integration-tests/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/39-creating-integration-tests/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Creating integration tests
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/4-creating-custom-errors/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/4-creating-custom-errors/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Creating custom errors
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/40-testnet-demo/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/40-testnet-demo/+page.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy the lottery on the testnet pt.1
-
+---
 _Follow along with this video:_
 
 ---

--- a/courses/foundry/4-smart-contract-lottery/41-implementing-console-log-in-your-smart-contract/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/41-implementing-console-log-in-your-smart-contract/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Implementing console log in your smart contract
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/42-debug-using-forge-test/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/42-debug-using-forge-test/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Debug using forge test
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/5-smart-contracts-events/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/5-smart-contracts-events/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Smart contracts events
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/6-random-numbers-block-timestamp/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/6-random-numbers-block-timestamp/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Smart contracts events
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/7-random-numbers-introduction-to-chainlink-vrf/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/7-random-numbers-introduction-to-chainlink-vrf/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Smart contracts events
+---
 
 _Follow along with this video:_
 

--- a/courses/foundry/4-smart-contract-lottery/8-implement-the-chainlink-vrf/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/8-implement-the-chainlink-vrf/+page.md
@@ -1,5 +1,6 @@
 ---
 title: Implement the Chainlink VRF
+---
 
 _Follow along with this video:_
 

--- a/courses/intermediate-python-vyper-smart-contract-development/2-web3py/25-recap/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/2-web3py/25-recap/+page.md
@@ -1,3 +1,7 @@
+---
+title: Recap
+---
+
 ## Recap
 
 We learned a lot of useful blockchain and Python fundamentals in this section. Let's take a look at what we covered.

--- a/courses/intermediate-python-vyper-smart-contract-development/4-mox-favs/8-shell/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/4-mox-favs/8-shell/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Shell
-        ---
+title: Shell
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/1-intro/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/1-intro/+page.md
@@ -1,3 +1,7 @@
+---
+title: Moccasin ERC20 Introduction
+---
+
 ## Moccasin ERC20 Introduction
 
 We are about to learn a ton about ERC20 tokens, and how to deploy them. We'll also see a bug that we'll intentionally create in our smart contract.

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/10-built-in-interfaces/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/10-built-in-interfaces/+page.md
@@ -1,3 +1,7 @@
+---
+title: Vyper Built-in Interfaces
+---
+
 ## Vyper Built-in Interfaces
 
 This lesson will explore the built-in interfaces provided by the Vyper compiler.

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/11-deploy-scripts/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/11-deploy-scripts/+page.md
@@ -1,3 +1,7 @@
+---
+title: Deploy Scripts
+---
+
 ## Deploy Scripts
 
 Let's write a deployment script. We can create a function called:

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/12-tests/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/12-tests/+page.md
@@ -1,3 +1,7 @@
+---
+title: Tests
+---
+
 ## Tests
 
 We've deployed our contract, and now we're ready to write some tests. We're not going to go in-depth with writing tests in this video, but we'll show a simple test case to get you started. 

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/13-events/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/13-events/+page.md
@@ -1,3 +1,7 @@
+---
+title: Events in our Raffle.sol
+---
+
 ## Lesson 9: Events in our Raffle.sol
 
 In this lesson, we learn about events. You might think you're familiar with events, but you're really not. Let's dive into that.

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/14-testing-events/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/14-testing-events/+page.md
@@ -1,3 +1,7 @@
+---
+title: Testing for Events
+---
+
 ## Testing for Events
 
 We've learned what events are and what they're used for. Let's look at our `snek_token` and see if we need to add it anywhere. Okay, maybe for this mint function. Okay, maybe for our initial deploy, but actually, does this mint function already emit logs? Let's take a look. And, yep, it sure does. Okay, so we don't need to do any logging on our `snek_token`. Our `snek_token` is good. 

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/2-setup/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/2-setup/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Setup
-        ---
+title: Setup
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/20-stateful-fuzz/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/20-stateful-fuzz/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Stateful Fuzz
-        ---
+title: Stateful Fuzz
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/21-workshop/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/21-workshop/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Workshop
-        ---
+title: Workshop
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/22-rng/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/22-rng/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Rng
-        ---
+title: Rng
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/23-cei/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/23-cei/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Cei
-        ---
+title: Cei
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/24-mox-console/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/24-mox-console/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Mox Console
-        ---
+title: Mox Console
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/25-recap/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/25-recap/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Recap
-        ---
+title: Recap
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/3-custom-pyproject/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/3-custom-pyproject/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Custom Pyproject
-        ---
+title: Custom Pyproject
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/4-what-is-erc20/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/4-what-is-erc20/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: What Is Erc20
-        ---
+title: What Is Erc20
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/5-build-it/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/5-build-it/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Build It
-        ---
+title: Build It
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/6-mox-libs-git/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/6-mox-libs-git/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Mox Libs Git
-        ---
+title: Mox Libs Git
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/7-mox-libs-pypi/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/7-mox-libs-pypi/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Mox Libs Pypi
-        ---
+title: Mox Libs Pypi
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/8-mox-idk/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/8-mox-idk/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Mox Idk
-        ---
+title: Mox Idk
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/9-init-supply/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/8-mox-erc20/9-init-supply/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Init Supply
-        ---
+title: Init Supply
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/9-how-to-get-hired/1-intro/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/9-how-to-get-hired/1-intro/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Intro
-        ---
+title: Intro
+---

--- a/courses/intermediate-python-vyper-smart-contract-development/9-how-to-get-hired/2-workshop/+page.md
+++ b/courses/intermediate-python-vyper-smart-contract-development/9-how-to-get-hired/2-workshop/+page.md
@@ -1,3 +1,3 @@
 ---
-        title: Workshop
-        ---
+title: Workshop
+---

--- a/courses/security/7-bridges/30-gas-bomb/+page.md
+++ b/courses/security/7-bridges/30-gas-bomb/+page.md
@@ -1,5 +1,5 @@
 ---
-title: Exploit: Exploit - Gas Bomb
+title: "Exploit: Exploit - Gas Bomb"
 ---
 
 _Follow along with the video lesson:_


### PR DESCRIPTION
This fixes all the markdown files that have some errors due to `gray-matter` parsing.
I wrote a script to get a list of all those files, and add a fix.

Mostly it was either a missing frontmatter issue, or a formatting error that caused `gray-matter` to error.

In the past 7 days, we had 17k such errors logged on Datadog. Hopefully, this PR will bring them to near 0.

Initial report file: [courses-markdown.json](https://github.com/user-attachments/files/18520622/courses-markdown.json)
