### PR TITLE
In the written lesson `error name is directly used without accessing it through contract object`

### DIFF
--- a/courses/advanced-foundry/3-develop-defi-protocol/11-defi-tests/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/11-defi-tests/+page.md
@@ -189,7 +189,7 @@ function testRevertsIfCollateralZero() public {
     vm.startPrank(USER);
     ERC20Mock(weth).approve(address(dsce), AMOUNT_COLLATERAL);
 
-    vm.expectRevert(DSCEngine__NeedsMoreThanZero.selector);
+    vm.expectRevert(DSCEngine.DSCEngine__NeedsMoreThanZero.selector);
     dsce.depositCollateral(weth, 0);
     vm.stopPrank();
 }


### PR DESCRIPTION
### The change is in Advance Foundry section 3 Develop a Defi protocol - written lesson 13 

https://updraft.cyfrin.io/courses/advanced-foundry/develop-defi-protocol/test-defi-protocol
```javascript
function testRevertsIfCollateralZero() public {
    vm.startPrank(USER);
    ERC20Mock(weth).approve(address(dsce), AMOUNT_COLLATERAL);

 @> vm.expectRevert(DSCEngine__NeedsMoreThanZero.selector);
    dsce.depositCollateral(weth, 0);
    vm.stopPrank();
}
```
## Fix:
The error name is directly called instead of calling from contract object.

Contractg object is added `DSCEngine`
```javascript
function testRevertsIfCollateralZero() public {

 @> vm.expectRevert(DSCEngine.DSCEngine__NeedsMoreThanZero.selector);
   
}
```

## Link to the issue:
https://github.com/Cyfrin/Updraft/issues/328