### PR TITLE
Smart Contract Security, Section 3: Fix typos and image

### DIFF
--- a/courses/security/3-first-audit/10-exploit-public-data/+page.md
+++ b/courses/security/3-first-audit/10-exploit-public-data/+page.md
@@ -56,7 +56,8 @@ I'll give you a hint: `State Variables`.
 
 <details closed>
 <summary>The Vulnerability</summary>
- ::image{src='/security-section-3/10-exploit-public-data/public-data2.png' style='width: 100%; height: auto;'}
+
+::image{src='/security-section-3/10-exploit-public-data/public-data2.png' style='width: 100%; height: auto;'}
 
 We've uncovered a major flaw in the business logic of this protocol. It's best we make a note of this.
 

--- a/courses/security/3-first-audit/11-recap-ii/+page.md
+++ b/courses/security/3-first-audit/11-recap-ii/+page.md
@@ -2,7 +2,7 @@
 title: Recap II
 ---
 
-_Follow along with this video:_\
+_Follow along with this video:_
 
 ---
 

--- a/courses/security/3-first-audit/11-recap-ii/+page.md
+++ b/courses/security/3-first-audit/11-recap-ii/+page.md
@@ -8,7 +8,7 @@ _Follow along with this video:_
 
 Let's recap a few of the things we've found while reviewing this protocol so far.
 
-### Vulnerability #1
+### Vulnerability 1
 
 First, we found that the `setPassword()` function, while intending to only callable by the `owner`, has no check to ensure this.
 
@@ -24,7 +24,7 @@ This is an `Access Control` vulnerability, allowing anyone to change the passwor
 ```js
 function setPassword(string memory newPassword) external {
   if (msg.sender !== s_owner) {
-  revert PasswordStore__NotOwner;
+    revert PasswordStore__NotOwner;
   }
   s_password = newPassword;
   emit SetNetPassword();
@@ -67,4 +67,4 @@ To sum up our findings:
 
 Great work in spotting these vulnerabilities! We've already shown that we're capable of making this protocol more secure.
 
-In the next lesson we're going to go over some test assessment.
+In the next lesson, we're going to go over some test assessment.

--- a/courses/security/3-first-audit/16-proof-of-code/+page.md
+++ b/courses/security/3-first-audit/16-proof-of-code/+page.md
@@ -88,15 +88,15 @@ I show one such method of reading any data off chain below.
 :br
 **Proof of Concept:**The below test case shows how anyone could read the password directly from the blockchain. We use foundry's cast tool to read directly from the storage of the contract, without being the owner.
 
-    Create a locally running chain
+Create a locally running chain
 
-make anvil
+    make anvil
 
-    Deploy the contract to the chain
+Deploy the contract to the chain
 
-make deploy
+    make deploy
 
-    Run the storage tool
+Run the storage tool
 
 We use 1 because that's the storage slot of s_password in the contract.
 

--- a/courses/security/3-first-audit/3-details/+page.md
+++ b/courses/security/3-first-audit/3-details/+page.md
@@ -142,7 +142,7 @@ Our client reports that there are **No** known issues with their codebase. I lov
 
 ### Local Setup
 
-. Go ahead and follow the `quick start` guide our client as provided.
+Go ahead and follow the `quick start` guide our client as provided.
 
 ```md
 git clone https://github.com/Cyfrin/3-passwordstore-audit

--- a/courses/security/3-first-audit/4-cloc/+page.md
+++ b/courses/security/3-first-audit/4-cloc/+page.md
@@ -50,7 +50,7 @@ This is what the output might look like:
 
 ### The Importance of Knowing Your Codebase Size
 
-Why is knowing the number of source lines of code (also referred to as Nsloc) crucial? The answer lies in the process of auditing and security research.
+Why is knowing the number of source lines of code (also referred to as nSLOC) crucial? The answer lies in the process of auditing and security research.
 
 As you perform more audits and delve further into security research, you'll start to gauge the pace at which you can audit a code base. Understanding that pace enables you to estimate more accurately the time required for future coding or auditing tasks based on the size of the code base.
 

--- a/courses/security/3-first-audit/7-context/+page.md
+++ b/courses/security/3-first-audit/7-context/+page.md
@@ -20,7 +20,7 @@ If we're following `The Tincho` method, our first step is going to be reading th
 
 > You can also open the preview pane by opening your command pallet and typing `markdown open preview`.
 
-_Quick tip: Check if an extension must be installed for Vs Code if it's not working for you._
+_Quick tip: Check if an extension must be installed for VS Code if it's not working for you._
 
 ::image{src='/security-section-3/7-context/context2.png' style='width: 100%; height: auto;'}
 


### PR DESCRIPTION
1. Fixed some typos.
2. Inserted newline and removed the space in front of `::image{}` that is preventing the image from displaying.

<img width="1618" alt="Screenshot 2025-01-24 at 7 15 17 PM" src="https://github.com/user-attachments/assets/a5b89fd3-6750-44f4-8170-299d4a2a80f6" />
