### PR TITLE
Page.md spelling updates: linkToken to link; VRFCoordinatorV2Mock to VRFCoordinatorV2_5Mock; activeNetworkConfig to localNetworkConfig; activeNetworkConfig() to getConfig()

### DIFF
--- a/courses/foundry/4-smart-contract-lottery/19-tests-and-deploy-the-lotterys-smart-contract-pt1/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/19-tests-and-deploy-the-lotterys-smart-contract-pt1/+page.md
@@ -29,7 +29,7 @@ function run() external returns (Raffle, HelperConfig) {
         uint64 subscriptionId;
         uint32 callbackGasLimit;
 
-    ) = helperConfig.activeNetworkConfig();
+    ) = helperConfig.getConfig();
 
 }
 ```
@@ -92,7 +92,7 @@ function run() external returns (Raffle, HelperConfig) {
         bytes32 gasLane,
         uint64 subscriptionId,
         uint32 callbackGasLimit
-    ) = helperConfig.activeNetworkConfig();
+    ) = helperConfig.getConfig();
 
     vm.startBroadcast();
     Raffle raffle = new Raffle(
@@ -141,7 +141,7 @@ contract RaffleTest is Test {
             subscriptionId,
             callbackGasLimit
 
-        ) = helperConfig.activeNetworkConfig();
+        ) = helperConfig.getConfig();
     }
 }
 ```
@@ -156,7 +156,7 @@ This seems like a lot, but it isn't, let's go through it.
 - Then, we created a new user called `PLAYER` and defined how many tokens they should receive;
 - Inside the `setUp` function, we deploy the `DeployRaffle` contract then we use it to deploy the `Raffle` and `HelperConfig` contracts;
 - We `deal` the `PLAYER` the defined `STARTING_USER_BALANCE`;
-- We call `helperConfig.activeNetworkConfig` to get the Raffle configuration parameters.
+- We call `helperconfig.getConfig()` to get the Raffle configuration parameters.
 
 Amazing! With all these done let's write a small test to ensure our `setUp` is functioning properly.
 

--- a/courses/foundry/4-smart-contract-lottery/20-deploy-script/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/20-deploy-script/+page.md
@@ -116,7 +116,7 @@ In case we are on a local chain but the VRF coordinator has already been set, we
 
 ```solidity
 function getOrCreateAnvilEthConfig() public returns (NetworkConfig memory) {
-    // Check to see if we set an active network config
+    // Check to see if we set an active network localNetworkConfig
     if (localNetworkConfig.vrfCoordinator != address(0)) {
         return localNetworkConfig;
 }

--- a/courses/foundry/4-smart-contract-lottery/21-deploy-a-mock-chainlink-vrf/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/21-deploy-a-mock-chainlink-vrf/+page.md
@@ -17,14 +17,14 @@ function getOrCreateAnvilEthConfig()
     public
     returns (NetworkConfig memory anvilNetworkConfig)
 {
-    // Check to see if we set an active network config
-    if (activeNetworkConfig.vrfCoordinator != address(0)) {
-        return activeNetworkConfig;
+    // Check to see if we set an active network localNetworkConfig
+    if (localNetworkConfig.vrfCoordinator != address(0)) {
+        return localNetworkConfig;
     }
 }
 ```
 
-We need to treat the other side of the `(activeNetworkConfig.vrfCoordinatorV2 != address(0))` condition. What happens if that is false?
+We need to treat the other side of the `(localNetworkConfig.vrfCoordinatorV2 != address(0))` condition. What happens if that is false?
 
 If that is false we need to deploy a mock vrfCoordinatorV2_5 and pass its address inside a `NetworkConfig` that will be used on Anvil. 
 
@@ -40,7 +40,7 @@ Add the following line in the imports section of `HelperConfig.s.sol`:
 import {VRFCoordinatorV2_5Mock} from "chainlink/src/v0.8/vrf/mocks/VRFCoordinatorV2_5Mock.sol";
 ```
 
-Amazing! Now let's keep on working on the `getOrCreateAnvilEthConfig` function. We need to deploy the `vrfCoordinatorV2Mock`, but if we open it we'll see that its constructor requires some parameters:
+Amazing! Now let's keep on working on the `getOrCreateAnvilEthConfig` function. We need to deploy the `vrfCoordinatorV2_5Mock`, but if we open it we'll see that its constructor requires some parameters:
 
 ```solidity
 contract VRFCoordinatorV2_5Mock is SubscriptionAPI, IVRFCoordinatorV2Plus {

--- a/courses/foundry/4-smart-contract-lottery/22-tests-and-deploy-the-lotterys-smart-contract-p2/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/22-tests-and-deploy-the-lotterys-smart-contract-p2/+page.md
@@ -73,7 +73,7 @@ We start with the `SPDX `and `pragma solidity` declarations. Then, we import `Sc
 
 We created a new struct called `NetworkConfig` and we matched its contents with the Raffle's constructor input.
 
-Great! Now let's design a function that returns the proper config for Sepolia:
+Great! Now let's design a function that returns the proper localNetworkConfig for Sepolia:
 
 ```solidity
 function getSepoliaEthConfig()
@@ -94,15 +94,15 @@ function getSepoliaEthConfig()
 
 The function above returns a `NetworkConfig` struct with data taken from [here](https://docs.chain.link/vrf/v2-5/supported-networks#sepolia-testnet). The `interval`, `entranceFee` and `callbackGasLimit` were selected by Patrick.
 
-Ok, we need a couple more things. We need a constructor that checks what blockchain we are on and attributes a state variable, let's call it `activeNetworkConfig`, the proper config for the chain used.
+Ok, we need a couple more things. We need a constructor that checks what blockchain we are on and attributes a state variable, let's call it `localNetworkConfig`, the proper localNetworkConfig for the chain used.
 
 ```solidity
-NetworkConfig public activeNetworkConfig;
+NetworkConfig public localNetworkConfig;
 constructor() {
     if (block.chainid == 11155111) {
-        activeNetworkConfig = getSepoliaEthConfig();
+        localNetworkConfig = getSepoliaEthConfig();
     } else {
-        activeNetworkConfig = getOrCreateAnvilEthConfig();
+        localNetworkConfig = getOrCreateAnvilEthConfig();
     }
 }
 ```
@@ -116,10 +116,10 @@ function getOrCreateAnvilEthConfig()
     public
     returns (NetworkConfig memory anvilNetworkConfig)
 {
-    // Check to see if we set an active network config
-    if (activeNetworkConfig.vrfCoordinator != address(0)) {
-        return activeNetworkConfig;
+    // Check to see if we set an active network localNetworkConfig
+    if (localNetworkConfig.vrfCoordinator != address(0)) {
+        return config;
     }
 }
 ```
-We check if the `activeNetworkConfig` is populated, and if is we return it. If not we need to deploy some mocks. But more on that in the next lesson.
+We check if the `localNetworkConfig` is populated, and if is we return it. If not we need to deploy some mocks. But more on that in the next lesson.

--- a/courses/foundry/4-smart-contract-lottery/28-subscribing-to-events/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/28-subscribing-to-events/+page.md
@@ -16,7 +16,7 @@ At the end, we see this:
 
 ```
     ├─ [31556] Raffle::performUpkeep(0x)
-    │   ├─ [5271] VRFCoordinatorV2Mock::requestRandomWords(0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c, 0, 3, 500000 [5e5], 1)
+    │   ├─ [5271] VRFCoordinatorV2_5Mock::requestRandomWords(0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c, 0, 3, 500000 [5e5], 1)
     │   │   └─ ← [Revert] InvalidConsumer()
     │   └─ ← [Revert] InvalidConsumer()
     └─ ← [Revert] InvalidConsumer()
@@ -24,7 +24,7 @@ At the end, we see this:
 
 It looks like when we call `performUpkeep` it internally calls `requestRandomWords`, and somewhere inside we hit an error.
 
-Go to `HelperConfig.s.sol` and try to follow the path of the `VRFCoordinatorV2Mock`. Inside we can see why our function failed:
+Go to `HelperConfig.s.sol` and try to follow the path of the `VRFCoordinatorV2_5Mock`. Inside we can see why our function failed:
 
 ```solidity
 modifier onlyValidConsumer(uint64 _subId, address _consumer) {
@@ -72,7 +72,7 @@ function run() external returns (uint64) {
 }
 ```
 
-Let's pause and talk about what we are doing and what we need to make things happen. Thinking back about what we did in Lesson 6. We created a subscription, we added a consumer and we funded the subscription. Open the `VRFCoordinatorV2Mock` and let's look for functions that we need to do it programmatically:
+Let's pause and talk about what we are doing and what we need to make things happen. Thinking back about what we did in Lesson 6. We created a subscription, we added a consumer and we funded the subscription. Open the `VRFCoordinatorV2_5Mock` and let's look for functions that we need to do it programmatically:
 
 ```solidity
 function createSubscription() external override returns (uint64 _subId) {
@@ -129,7 +129,7 @@ contract CreateSubscription is Script {
             ,
             ,
             ,
-        ) = helperConfig.activeNetworkConfig();
+        ) = helperConfig.getConfig();
 
         return createSubscription(vrfCoordinator);
     }
@@ -147,12 +147,12 @@ contract CreateSubscription is Script {
 
 As we said above, we created a `run` function that calls `createSubscriptionUsingConfig`. This function deploys the `HelperConfig` to grab the `vrfCoordinator` and inside the return statement, we call the `createSubscription` function. For that to work, we need to define the `createSubscription` function, which takes the `vrfCoordinator` address as an input. This is where we create the actual subscription.
 
-Amazing! Let's work on the `createSubscription` function. We need to import some things to make it work. First, let's update the contract in order to import `console`, to log a message every time we create a subscription. Second, let's import the `VRFCoordinatorV2Mock` to be able to call the functions we specified above.
+Amazing! Let's work on the `createSubscription` function. We need to import some things to make it work. First, let's update the contract in order to import `console`, to log a message every time we create a subscription. Second, let's import the `VRFCoordinatorV2_5Mock` to be able to call the functions we specified above.
 
 ```solidity
 import {Script, console} from "forge-std/Script.sol";
 import {HelperConfig} from "./HelperConfig.s.sol";
-import {VRFCoordinatorV2Mock} from "chainlink/src/v0.8/vrf/mocks/VRFCoordinatorV2Mock.sol";
+import {VRFCoordinatorV2_5Mock} from "chainlink/src/v0.8/vrf/mocks/VRFCoordinatorV2_5Mock.sol";
 ```
 
 Perfect, not let's finish the `createSubscription`:
@@ -163,7 +163,7 @@ function createSubscription(
 ) public returns (uint64) {
     console.log("Creating subscription on ChainID: ", block.chainid);
     vm.startBroadcast();
-    uint64 subId = VRFCoordinatorV2Mock(vrfCoordinator).createSubscription();
+    uint64 subId = VRFCoordinatorV2_5Mock(vrfCoordinator).createSubscription();
     vm.stopBroadcast();
     console.log("Your sub Id is: ", subId);
     console.log("Please update subscriptionId in HelperConfig!");
@@ -171,7 +171,7 @@ function createSubscription(
 }
 ```
 
-First, we log the `Creating subscription` message. Then, we encapsulate the `VRFCoordinatorV2Mock(vrfCoordinator).createSubscription();` call inside the `vm.startBroadcast` and `vm.stopBroadcast` block. We assign the return of the `VRFCoordinatorV2Mock(vrfCoordinator).createSubscription` call to `uint64 subId` variable. Then we log the `subId` and return it to end the function.
+First, we log the `Creating subscription` message. Then, we encapsulate the `VRFCoordinatorV2_5Mock(vrfCoordinator).createSubscription();` call inside the `vm.startBroadcast` and `vm.stopBroadcast` block. We assign the return of the `VRFCoordinatorV2_5Mock(vrfCoordinator).createSubscription` call to `uint64 subId` variable. Then we log the `subId` and return it to end the function.
 
 Amazing work! Coming back to `DeployRaffle.s.sol`, we should create a subscription if we don't have one, like this:
 
@@ -191,7 +191,7 @@ contract DeployRaffle is Script {
         bytes32 gasLane,
         uint64 subscriptionId,
         uint32 callbackGasLimit
-        ) = helperConfig.activeNetworkConfig();
+        ) = helperConfig.getConfig();
 
         if (subscriptionId == 0) {
             CreateSubscription createSubscription = new CreateSubscription();

--- a/courses/foundry/4-smart-contract-lottery/30-fund-subscription/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/30-fund-subscription/+page.md
@@ -98,7 +98,7 @@ And now, with this new import, we can deploy the token in case we use Anvil like
 
 ```solidity
 function getOrCreateAnvilEthConfig() internal returns (NetworkConfig memory) {
-    // Check to see if we set an active network config
+    // Check to see if we set an active network localNetworkConfig
     if (localNetworkConfig.vrfCoordinator != address(0)) {
         return localNetworkConfig;
     }
@@ -149,7 +149,7 @@ Error (7364): Different number of components on the left hand side (6) than on t
 Error (7407): Type tuple(uint256,uint256,address,bytes32,uint64,uint32,address) is not implicitly convertible to expected type tuple(uint256,uint256,address,bytes32,uint64,uint32).
   --> test/unit/RaffleTest.t.sol:42:13:
    |
-42 |         ) = helperConfig.localNetworkConfig();
+42 |         ) = helperConfig.getConfig();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ```
 
@@ -266,7 +266,7 @@ This seems like a lot, but it isn't, let's go through it step by step:
 
 - Like any other Script our's has a `run` function that gets executed
 - Inside we call the `fundSubscriptionUsingConfig` function
-- Inside the `fundSubscriptionUsingConfig` function we get the `activeNetworkConfig` that provides the chain-appropriate `vrfCoordinator`, `subscriptionId` and `link` token address
+- Inside the `fundSubscriptionUsingConfig` function we get the `config` that provides the chain-appropriate `vrfCoordinator`, `subscriptionId` and `link` token address
 - At the end of `fundSubscriptionUsingConfig` we call the `fundSubscription`, a function that we are going to define
 - We define `fundSubscription` as a public function that takes the 3 parameters as input
 - We console log some details, this will help us debug down the road

--- a/courses/foundry/4-smart-contract-lottery/30-fund-subscription/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/30-fund-subscription/+page.md
@@ -121,7 +121,7 @@ function getOrCreateAnvilEthConfig() internal returns (NetworkConfig memory) {
         gasLane: 0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae,
         subscriptionId: 0,
         callbackGasLimit: 500_000,
-        linkToken: address(linkToken)
+        link: address(linkToken)
     });
 
     return localNetworkConfig;
@@ -182,7 +182,7 @@ function fundSubscriptionUsingConfig() public {
     HelperConfig helperConfig = new HelperConfig();
     address vrfCoordinator = helperConfig.getConfig().vrfCoordinator;
     uint256 subscriptionId = helperConfig.getConfig().subscriptionId;
-    address linkToken = helperConfig.getConfig().linkToken;
+    address linkToken = helperConfig.getConfig().link;
 
     fundSubscription(vrfCoordinator, subscriptionId, linkToken);
 }
@@ -223,7 +223,7 @@ contract FundSubscription is Script, CodeConstants {
         HelperConfig helperConfig = new HelperConfig();
         address vrfCoordinator = helperConfig.getConfig().vrfCoordinator;
         uint256 subscriptionId = helperConfig.getConfig().subscriptionId;
-        address linkToken = helperConfig.getConfig().linkToken;
+        address linkToken = helperConfig.getConfig().link;
 
         if (subscriptionId == 0) {
             CreateSubscription createSub = new CreateSubscription();

--- a/courses/foundry/4-smart-contract-lottery/31-adding-a-consumer/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/31-adding-a-consumer/+page.md
@@ -48,7 +48,7 @@ contract AddConsumer is Script {
         console.log("On chain id: ", block.chainid);
 
         vm.startBroadcast();
-        VRFCoordinatorV2Mock(vrfCoordinator).addConsumer(subscriptionId, raffle);
+        VRFCoordinatorV2_5Mock(vrfCoordinator).addConsumer(subscriptionId, raffle);
         vm.stopBroadcast();
     }
 
@@ -61,7 +61,7 @@ contract AddConsumer is Script {
             ,
             uint64 subscriptionId,
             ,
-        ) = helperConfig.activeNetworkConfig();
+        ) = helperConfig.getConfig();
         addConsumer(raffle, vrfCoordinator, subscriptionId);
 
     }
@@ -78,11 +78,11 @@ So... what happened here?
 1. We used `DevOpsTools` to grab the last deployment of the `Raffle` contract inside the `run` function;
 2. We also call `addConsumerUsingConfig` inside the `run` function;
 3. We define `addConsumerUsingConfig` as a public function taking an address as an input;
-4. We deploy a new `HelperConfig` and call `activeNetworkConfig` to grab the `vrfCoordinate` and `subscriptionId` addresses;
+4. We deploy a new `HelperConfig` and call `getConfig()` to grab the `vrfCoordinate` and `subscriptionId` addresses;
 5. We call the `addConsumer` function;
 6. We define `addConsumer` as a public function taking 3 input parameters: address of the `raffle` contract, address of `vrfCoordinator` and `subscriptionId`;
 7. We log some things useful for debugging;
-8. Then, inside a `startBroadcast`- `stopBroadcast` block we call the `addConsumer` function from the `VRFCoordinatorV2Mock` using the right input parameters;
+8. Then, inside a `startBroadcast`- `stopBroadcast` block we call the `addConsumer` function from the `VRFCoordinatorV2_5Mock` using the right input parameters;
 
 Try a nice `forge build` and check if everything is compiling. Perfect!
 

--- a/courses/foundry/4-smart-contract-lottery/35-refactoring-events-data/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/35-refactoring-events-data/+page.md
@@ -45,7 +45,7 @@ function performUpkeep(bytes calldata /* performData */) external override {
 
 At this point in the video, Patrick asks the audience if this event is redundant. This is an amazing question to ask yourself every time you do something in Solidity because as you know, everything costs gas. Another absolute truth about this environment is that no one wants to pay gas. So we, as developers, need to write efficient code.
 
-To answer Patrick's question: Yes it's redundant, inside the `VRFCoordinatorV2Mock` you'll find that the `requestRandomWords` emits a giant event called `RandomWordsRequested` that contains the `requestId` we are also emitting in our new event. You'll see this a lot in smart contracts that involve transfers. But more on that in future sections.
+To answer Patrick's question: Yes it's redundant, inside the `VRFCoordinatorV2_5Mock` you'll find that the `requestRandomWords` emits a giant event called `RandomWordsRequested` that contains the `requestId` we are also emitting in our new event. You'll see this a lot in smart contracts that involve transfers. But more on that in future sections.
 
 We will keep the event for now for testing purposes. 
 

--- a/courses/foundry/4-smart-contract-lottery/36-intro-to-fuzz-testing/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/36-intro-to-fuzz-testing/+page.md
@@ -37,7 +37,7 @@ function testFulfillRandomWordsCanOnlyBeCalledAfterPerformUpkeep()
 }
 ```
 
-So we define the function and use the modifier we created in the previous lesson to make `PLAYER` enter the raffle and set `block.timestamp` into the future. We use the `expectRevert` because we expect the next call to revert with the `"nonexistent request"` message. How do we know that? Simple, inside the `VRFCoordinatorV2Mock` we can see the following code:
+So we define the function and use the modifier we created in the previous lesson to make `PLAYER` enter the raffle and set `block.timestamp` into the future. We use the `expectRevert` because we expect the next call to revert with the `"nonexistent request"` message. How do we know that? Simple, inside the `VRFCoordinatorV2_5Mock` we can see the following code:
 
 
 ```solidity

--- a/courses/foundry/4-smart-contract-lottery/38-forked-test-environment-and-dynamic-private-keys/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/38-forked-test-environment-and-dynamic-private-keys/+page.md
@@ -554,9 +554,9 @@ If you try to build the project now you'll most likely face a plethora of errors
 
 Please ensure that all the scripts, tests and main contracts use `pragma solidity ^0.8.19;`. Make sure to change the pragma of the following files `lib/chainlink/contracts/src/v0.8/vrf/dev/VRFCoordinatorV2_5.sol` and `lib/chainlink/contracts/src/v0.8/vrf/dev/SubscriptionAPI.sol` to `pragma solidity ^0.8.19;`. You shouldn't do this in any other cases. We do it for tutorial purposes. Inside `lib/chainlink/contracts/src/v0.8/vendor/@eth-optimism/contracts/v0.8.9/contracts/L2/predeploys/OVM_GasPriceOracle.sol` modify the `Ownable()` call from the constructor into `Ownable(_owner)`
 
-In `HelperConfig.s.sol` delete the existing import for `VRFCoordinatorV2Mock` and replace it with the following `import {VRFCoordinatorV2PlusMock} from "chainlink/src/v0.8/vrf/mocks/VRFCoordinatorV2PlusMock.sol";`. Change the VRF Mock deployment line in `getOrCreateAnvilEthConfig` from `VRFCoordinatorV2Mock vrfCoordinatorV2Mock = new VRFCoordinatorV2Mock(baseFee, gasPriceLink);` to `VRFCoordinatorV2PlusMock vrfCoordinatorV2Mock = new VRFCoordinatorV2PlusMock(baseFee, gasPriceLink);`
+In `HelperConfig.s.sol` delete the existing import for `VRFCoordinatorV2_5Mock` and replace it with the following `import {VRFCoordinatorV2PlusMock} from "chainlink/src/v0.8/vrf/mocks/VRFCoordinatorV2PlusMock.sol";`. Change the VRF Mock deployment line in `getOrCreateAnvilEthConfig` from `VRFCoordinatorV2_5Mock VRFCoordinatorV2_5Mock = new VRFCoordinatorV2_5Mock(baseFee, gasPriceLink);` to `VRFCoordinatorV2PlusMock VRFCoordinatorV2_5Mock = new VRFCoordinatorV2PlusMock(baseFee, gasPriceLink);`
 
-In `Interactions.s.sol` delete the existing import for `VRFCoordinatorV2Mock` and replace it with the following `import {VRFCoordinatorV2PlusMock} from "chainlink/src/v0.8/vrf/mocks/VRFCoordinatorV2PlusMock.sol";`. For all 3 existing contracts, create and fund subscriptions and add consumer perform a call to a function from `VRFCoordinatorV2Mock`, make sure to replace `VRFCoordinatorV2Mock` with `VRFCoordinatorV2PlusMock`.
+In `Interactions.s.sol` delete the existing import for `VRFCoordinatorV2_5Mock` and replace it with the following `import {VRFCoordinatorV2PlusMock} from "chainlink/src/v0.8/vrf/mocks/VRFCoordinatorV2PlusMock.sol";`. For all 3 existing contracts, create and fund subscriptions and add consumer perform a call to a function from `VRFCoordinatorV2_5Mock`, make sure to replace `VRFCoordinatorV2_5Mock` with `VRFCoordinatorV2_5Mock`.
 
 Make sure to add your `subscriptionId`, which you got by following the tutorial related to obtaining it using the Chainlink UI, inside the `HelperConfig::getSepoliaEthConfig` function.
 
@@ -598,7 +598,7 @@ It failed on setup:
 ```
     │   │   ├─ [0] VM::startBroadcast()
     │   │   │   └─ ← [Return]
-    │   │   ├─ [236] VRFCoordinatorV2::addConsumer(5000032745829988966686682423284879867102409618787289144283231874950241281744 [5e75], Raffle: [0x90193C961A926261B756D1E5bb255e67ff9498A1])
+    │   │   ├─ [236] VRFCoordinatorV2_5Mock::addConsumer(5000032745829988966686682423284879867102409618787289144283231874950241281744 [5e75], Raffle: [0x90193C961A926261B756D1E5bb255e67ff9498A1])
     │   │   │   └─ ← [Revert] EvmError: Revert
     │   │   └─ ← [Revert] EvmError: Revert
     │   └─ ← [Revert] EvmError: Revert
@@ -613,16 +613,16 @@ We need to make sure that we add a consumer using the same private key (account)
 You could say, `ok, I get it, let's hardcode the subscriptionId inside the HelperConfig::getSepoliaEthConfig function to 0, so our script create a new subscription`. That is a very smart thing to say, but if you do that you'll get this outcome:
 
 ```
-    │   ├─ [9690] FundSubscription::fundSubscription(VRFCoordinatorV2: [0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625], 11932 [1.193e4], LinkToken: [0x779877A7B0D9E8603169DdbD7836e478b4624789])
+    │   ├─ [9690] FundSubscription::fundSubscription(VRFCoordinatorV2_5Mock: [0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625], 11932 [1.193e4], LinkToken: [0x779877A7B0D9E8603169DdbD7836e478b4624789])
     │   │   ├─ [0] console::log("Funding subscription: ", 11932 [1.193e4]) [staticcall]
     │   │   │   └─ ← [Stop]
-    │   │   ├─ [0] console::log("Using vrfCoordinator: ", VRFCoordinatorV2: [0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625]) [staticcall]
+    │   │   ├─ [0] console::log("Using vrfCoordinator: ", VRFCoordinatorV2_5Mock: [0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625]) [staticcall]
     │   │   │   └─ ← [Stop]
     │   │   ├─ [0] console::log("On ChainID: ", 11155111 [1.115e7]) [staticcall]
     │   │   │   └─ ← [Stop]
     │   │   ├─ [0] VM::startBroadcast()
     │   │   │   └─ ← [Return]
-    │   │   ├─ [3558] LinkToken::transferAndCall(VRFCoordinatorV2: [0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625], 3000000000000000000 [3e18], 0x0000000000000000000000000000000000000000000000000000000000002e9c)
+    │   │   ├─ [3558] LinkToken::transferAndCall(: [0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625], 3000000000000000000 [3e18], 0x0000000000000000000000000000000000000000000000000000000000002e9c)
     │   │   │   └─ ← [Revert] revert: ERC20: transfer amount exceeds balance
     │   │   └─ ← [Revert] revert: ERC20: transfer amount exceeds balance
     │   └─ ← [Revert] revert: ERC20: transfer amount exceeds balance
@@ -710,7 +710,7 @@ function getOrCreateAnvilEthConfig()
     return NetworkConfig({
         entranceFee: 0.01 ether,
         interval: 30, // 30 seconds
-        vrfCoordinator: address(vrfCoordinatorV2Mock),
+        vrfCoordinator: address(vrfCoordinatorV2_5Mock),
         gasLane: 0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae,
         subscriptionId: 0, // If left as 0, our scripts will create one!
         callbackGasLimit: 500000, // 500,000 gas
@@ -748,7 +748,7 @@ contract AddConsumer is Script {
             ,
             ,
             uint256 deployerKey
-        ) = helperConfig.activeNetworkConfig();
+        ) = helperConfig.getConfig();
         addConsumer(raffle, vrfCoordinator, subscriptionId, deployerKey);
 
     }
@@ -762,7 +762,7 @@ contract AddConsumer is Script {
 
 Let's understand the logic behind the change and then change it in the other two contracts `FundSubscription` and `CreateSubscription`.
 
-We start everything from `helperConfig.activeNetworkConfig` because the main change we want to bake in is the `NetworkConfig` change we did in `HelperConfig`. We get the `deployerKey` from the `helperConfig.activeNetworkConfig();` call. Then we use it in the `addConsumer` function, providing it as an input. Scrolling up to the `addConsumer` function, we need to define the 4th input `function addConsumer(address raffle, address vrfCoordinator, uint256 subscriptionId, uint256 deployerKey)`. Now that we have access to the `deployerKey` we can provide it in `vm.startBroadcast(deployerKey);`. So that `addConsumer` function will be called by the right account.
+We start everything from `helperconfig.getConfig()` because the main change we want to bake in is the `NetworkConfig` change we did in `HelperConfig`. We get the `deployerKey` from the `helperConfig.getConfig();` call. Then we use it in the `addConsumer` function, providing it as an input. Scrolling up to the `addConsumer` function, we need to define the 4th input `function addConsumer(address raffle, address vrfCoordinator, uint256 subscriptionId, uint256 deployerKey)`. Now that we have access to the `deployerKey` we can provide it in `vm.startBroadcast(deployerKey);`. So that `addConsumer` function will be called by the right account.
 
 We will perform the same changes to the other two contracts:
 
@@ -781,7 +781,7 @@ contract FundSubscription is Script {
             ,
             address link,
             uint256 deployerKey
-        ) = helperConfig.activeNetworkConfig();
+        ) = helperConfig.getConfig();
         fundSubscription(vrfCoordinator, subscriptionId, link, deployerKey);
     }
 
@@ -806,7 +806,7 @@ contract FundSubscription is Script {
 }
 ```
 
-We start with `fundSubscriptionUsingConfig` we add the `deployerKey` variable in the `activeNetworkConfig` call line. We use that newly acquired `deployerKey` inside the `fundSubscription` call, providing it as input. Going to `fundSubscription` we add the 4th input variable `uint256 deployerKey`. We use the new input in both `vm.startBroadcast` places.
+We start with `fundSubscriptionUsingConfig` we add the `deployerKey` variable in the `getConfig()` call line. We use that newly acquired `deployerKey` inside the `fundSubscription` call, providing it as input. Going to `fundSubscription` we add the 4th input variable `uint256 deployerKey`. We use the new input in both `vm.startBroadcast` places.
 
 ```solidity
 contract CreateSubscription is Script {
@@ -822,7 +822,7 @@ contract CreateSubscription is Script {
             ,
             ,
             uint256 deployerKey
-        ) = helperConfig.activeNetworkConfig();
+        ) = helperConfig.getConfig();
 
         return createSubscription(vrfCoordinator, deployerKey);
     }
@@ -878,12 +878,12 @@ Error (6160): Wrong argument count for function call: 3 arguments given but expe
 Error (7407): Type tuple(uint256,uint256,address,bytes32,uint256,uint32,address,uint256) is not implicitly convertible to expected type tuple(uint256,uint256,address,bytes32,uint256,uint32,address).
   --> test/unit/RaffleTest.t.sol:46:13:
    |
-46 |         ) = helperConfig.activeNetworkConfig();
+46 |         ) = helperConfig.getConfig();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ```
 
-Let's read it. We modified the 3 functions `createSubscription`, `fundSubscription` and `addConsumer`, we should reflect these changes inside `DeployRaffle.s.sol`. Then we are calling `helperConfig.activeNetworkConfig` in `Raffle.t.sol`, we should adjust that to reflect the changes of the `NetworkConfig` struct.
+Let's read it. We modified the 3 functions `createSubscription`, `fundSubscription` and `addConsumer`, we should reflect these changes inside `DeployRaffle.s.sol`. Then we are calling `helperconfig.getConfig()` in `Raffle.t.sol`, we should adjust that to reflect the changes of the `NetworkConfig` struct.
 
 Open the `DeployRaffle.s.sol` file and modify the 3 functions call to include `deployerKey` as an input parameter.
 
@@ -900,7 +900,7 @@ contract DeployRaffle is Script {
         uint32 callbackGasLimit,
         address link,
         uint256 deployerKey
-        ) = helperConfig.activeNetworkConfig();
+        ) = helperConfig.getConfig();
 
         if (subscriptionId == 0) {
             CreateSubscription createSubscription = new CreateSubscription();
@@ -931,7 +931,7 @@ contract DeployRaffle is Script {
 }
 ```
 
-Open the `RaffleTest.t.sol` and add the `deployerKey` in the variables section and in the `setUp` function where `helperConfig.activeNetworkConfig()` is called:
+Open the `RaffleTest.t.sol` and add the `deployerKey` in the variables section and in the `setUp` function where `helperConfig.getConfig()` is called:
 
 ```solidity
 contract RaffleTest is Test {
@@ -969,7 +969,7 @@ contract RaffleTest is Test {
             link,
             deployerKey
 
-        ) = helperConfig.activeNetworkConfig();
+        ) = helperConfig.getConfig();
     }
 }
 ```
@@ -1024,7 +1024,7 @@ contract RaffleTest is Test {
             link,
             // deployerKey
 
-        ) = helperConfig.activeNetworkConfig();
+        ) = helperConfig.getConfig();
     }
 }
 ```

--- a/courses/foundry/4-smart-contract-lottery/7-random-numbers-introduction-to-chainlink-vrf/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/7-random-numbers-introduction-to-chainlink-vrf/+page.md
@@ -64,7 +64,7 @@ uint256 public lastRequestId;
 
 This is the way the contract keeps track of the requests, their status and the `randomWords` provided as a response to the requests. The mapping uses the `requestId` as a key and the details regarding the request are stored inside the `RequestStatus` struct which acts as a mapping value. Given that we can't loop through mappings we will also have a `requestIds` array. We also record the `lastRequestId` for efficiency.
 
-We will also store the `subscriptionId` as a state variable, this will be checked inside the `requestRandomWords` by the `VRFCoordinatorV2`. If we don't have a valid subscription or we don't have enough funds our request will revert. 
+We will also store the `subscriptionId` as a state variable, this will be checked inside the `requestRandomWords` by the `VRFCoordinatorV2_5Mock`. If we don't have a valid subscription or we don't have enough funds our request will revert. 
 
 The next important piece is the `VRFCoordinatorV2Interface` which is one of the dependencies we import, this [contract](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/interfaces/VRFCoordinatorV2Interface.sol) has a lot of methods related to subscription management and requests, but the one we are interested in right now is `requestRandomWords`, this is the function that we need to call to trigger the process of receiving the random words, that we'll use as a source of randomness in our application.
 


### PR DESCRIPTION
# The PR consists of 4 spelling fixes in written lessons:

Issue link: https://github.com/Cyfrin/Updraft/issues/337 

1. Harmonizing property of NetworkConfig from linkToken to link. Moreover, link is used in video as well as in written lessons 30, 38
2. Updating VRFCoordinatorV2Mock to VRFCoordinatorV2_5Mock in all pages. The newest Mock for VRF is version 2.5. This is also used in the videos.
3. Changing activeNetworkConfig to localNetworkConfig. I saw that activeNetworkConfig is used in the videos for advanced foundry. However,  localNetworkConfig is used in the videos for foundry fundamentals.
4. Changing function call from activeNetworkConfig() to getConfig(). I saw that activeNetworkConfig is used in the videos for advanced foundry and in section 2 Fund Me. However, getConfig() is also used in the videos for smart-contract-lottery.