### PR TITLE
Advanced-Foundry: Section 2 - Video 3 | missing mintNft() function in written lesson

### DIFF
--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/3-foundry-setup/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/3-foundry-setup/+page.md
@@ -107,6 +107,12 @@ constructor() ERC721("Doggie", "DOG"){
 }
 ```
 
+Additionally, we want to add a function to mint NFTs. We will define it later:
+
+```solidity
+function mintNft() public {}
+```
+
 ### TokenURI
 
 It's hard to believe, but once upon a time the tokenUri was once considered an optional parameter, despite being integral to how NFTs are used and consumed today.


### PR DESCRIPTION
Adding mintNft() function to written lesson: 

Issue link: https://github.com/Cyfrin/Updraft/issues/345 

_Additionally, we want to add a function to mint NFTs. We will define it later:_

```solidity
function mintNft() public {}
```