### PR TITLE
Markdown code snippets from js to solidity

### DIFF
--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/12-svg-nft/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/12-svg-nft/+page.md
@@ -16,7 +16,7 @@ At the core of the NFT we'll build is a `flipMood` function which allows the own
 
 Start with creating the file `src/MoodNft.sol` and filling out the usual boilerplate. We're definitely getting good at this by now.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -30,13 +30,13 @@ contract MoodNft is ERC721 {
 
 Looking good! We want to store the `SVG` art on chain, we're actually going to pass these to our `constructor` on deployment.
 
-```js
+```solidity
 constructor(string memory sadSvg, string memory happySvg) ERC721("Mood NFT", "MN"){}
 ```
 
 We know we'll need a `tokenCounter`, along with this let's declare our `sadSvg` and `happySvg` as storage variables as well. All together, before getting into our functions, things should look like this:
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -58,7 +58,7 @@ contract MoodNft is ERC721 {
 
 Now we need a `mint` function, anyone should be able to call it, so it should definitely be `public`. This shouldn't be anything especially new to us so far.
 
-```js
+```solidity
 function mintNft() public {
     _safeMint(msg.sender, s_tokenCounter);
     s_tokenCounter++;
@@ -67,7 +67,7 @@ function mintNft() public {
 
 And now the moment of truth! As we write the `tokenURI` function, we know this is what defines what our NFT looks like and the metadata associated with it. Remember that we'll need to `override` this `virtual` function of the `ERC721` standard.
 
-```js
+```solidity
 function tokenURI(uint256 tokenId) public view override returns (string memory){}
 ```
 

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/13-svg-nft-encoding/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/13-svg-nft-encoding/+page.md
@@ -25,7 +25,7 @@ data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAyNHB4IiBoZWlnaHQ9IjEwMjRweCIgdmlld0
 
 Now, if we're going to be passing _already encoded_ imageURIs to our constructor, it's probably a good idea to adjust the naming of our storage variables for clarity. Let's do this before moving on.
 
-```js
+```solidity
 contract MoodNft is ERC721 {
     uint256 private s_tokenCounter;
     string private s_sadSvgImageUri;
@@ -49,13 +49,13 @@ OpenZeppelin actually offers a [**Utilities**](https://docs.openzeppelin.com/con
 
 We've already got OpenZeppelin contracts installed, so we can just import Base64 into our NFT contract.
 
-```js
+```solidity
 import { Base64 } from "@openzeppelin/contracts/utils/Base64.sol";
 ```
 
 Let's start off our tokenURI function by defining a variable, `string memory tokenMetadata`. We can set this equal to our JSON object in string format like so:
 
-```js
+```solidity
 string memory tokenMetadata = abi.encodePacked(
     '{"name: "',
     name(),
@@ -69,7 +69,7 @@ In the above, we're using `abi.encodePacked` to concatenate our disparate string
 
 In order to determine our imageURI we'll need to derive this from the mood which has been set to our NFT token. As such, we're going to need a way to track the mood of each token. This sounds like a mapping to me. We can even spice it up a little bit and map our choice to an `enum`, which would allow someone to set more moods, if they wanted to expand on things in the future.
 
-```js
+```solidity
 contract MoodNft is ERC721 {
     uint256 private s_tokenCounter;
     string private s_sadSvgImageUri;
@@ -86,7 +86,7 @@ contract MoodNft is ERC721 {
 
 When an NFT is minted, they'll need a default mood, let's default them to happy.
 
-```js
+```solidity
 function mintNft() public {
     _safeMint(msg.sender, s_tokenCounter);
     s_tokenIdToMood[s_tokenCounter] = Mood.HAPPY;
@@ -96,7 +96,7 @@ function mintNft() public {
 
 Now, back in our tokenURI function, we can define a conditional statement which will derive what our imageURI should be.
 
-```js
+```solidity
 function tokenURI(uint256 tokenId) public view override returns (string memory){
     string memory imageURI;
     if (s_tokenIfToMood[tokenId] == HAPPY) {
@@ -122,7 +122,7 @@ This is where things might get a little wild.
 
 Currently we have a string, in order to acquire the Base64 hash of this data, we need to first convert this string to bytes, we can do this with some typecasting.
 
-```js
+```solidity
 bytes(
   abi.encodePacked(
     '{"name: "',
@@ -136,7 +136,7 @@ bytes(
 
 Now we can apply our Base64 encoding to acquire our hash.
 
-```js
+```solidity
 Base64.encode(
   bytes(
     abi.encodePacked(
@@ -152,7 +152,7 @@ Base64.encode(
 
 At this point, our tokenURI data is formatting like our imageUris were. If you recall, we needed to prepend our data type prefix(`data:image/svg+xml;base64,`) to our Base64 hash in order for a browser to understand. A similar methodology applies to our tokenURI JSON but with a different prefix. Let's define a method to return this string for us. Fortunately the ERC721 standard has a \_baseURI function that we can override.
 
-```js
+```solidity
 function _baseURI() internal pure override returns(string memory){
     return "data:application/json;base64,"
 }
@@ -160,7 +160,7 @@ function _baseURI() internal pure override returns(string memory){
 
 Now, in our tokenURI function again, we can concatenate the result of this \_baseURI function with the Base64 encoding of our JSON object... and finally we can type cast all of this as a string to be returned by our tokenURI function.
 
-```js
+```solidity
 return string(
   abi.encodePacked(
     _baseURI(),
@@ -191,7 +191,7 @@ Admittedly, this is a lot at once. Before we add any more functionality, let's c
 
 Given the complexity of our tokenURI function, let's take a moment to write a quick test and assure it's returning what we'd expect it to. Create the file `test/MoodNftTest.t.sol` and set up our usual boilerplate.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -209,7 +209,7 @@ contract MoodNftTest is Test {
 
 We'll need to declare our Happy and Sad SVG URIs as constants in our test, we can use these in the deployment of our MoodNft contract within the setUp function of our Test.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -237,7 +237,7 @@ Finally we can write a test function. All that's required is to mint one of our 
 > import {Test, console} from "forge-std/Test.sol";`
 > ```
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/14-svg-nft-flipping/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/14-svg-nft-flipping/+page.md
@@ -14,7 +14,7 @@ Because our SVGs are on-chain, this affords us the ability to easily swap betwee
 
 Our first consideration should be that _only the owner_ of an NFT should be able to flip its mood. We can use the \_isApprovedOrOwner function, included within the ERC721 standard to verify this before our flipMood function execution.
 
-```js
+```solidity
 function flipMood(uint256 tokenId) public {
     if(!_isApprovedOrOwner(msg.sender, tokenId)){
         revert MoodNFT__CantFlipMoodIfNotOwner();
@@ -26,7 +26,7 @@ Remember to create our new custom error at the start of the contract! `error Moo
 
 From here, we'll just check if it NFT is happy, and if so, make it sad, otherwise we'll make it happy. This will flip the NFT's mood regardless of it's current mood.
 
-```js
+```solidity
 function flipMood(uint256 tokenId) public {
     if(!_isApprovedOrOwner(msg.sender, tokenId)){
         revert MoodNFT__CantFlipMoodIfNotOwner();

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/15-svg-deploy/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/15-svg-deploy/+page.md
@@ -12,7 +12,7 @@ In this lesson, we'll jump right into creating the script to deploy our MoodNFT 
 
 To begin, we'll need to create the file `script/DeployMoodNft.s.sol` and fill it with our script boilerplate.
 
-```js
+```solidity
 // SPDX-License-Identifier:MIT
 pragma solidity ^0.8.18;
 
@@ -28,7 +28,7 @@ Looks great! Now we should consider how we're mention to deploy MoodNft.sol. We 
 
 Let's start with creating this encoding function.
 
-```js
+```solidity
 function svgToImageURI(string memory svg) public purse returns (string memory){
     string memory baseURL = "data:image/svg+xml;base64,";
 }
@@ -36,7 +36,7 @@ function svgToImageURI(string memory svg) public purse returns (string memory){
 
 Set up like this, we can now use the Base64 offering from OpenZeppelin to encode the data passed to this function, and then concatenate it with our baseURI. We'll need to import Base64.
 
-```js
+```solidity
 // SPDX-License-Identifier:MIT
 pragma solidity ^0.8.18;
 
@@ -67,7 +67,7 @@ Before moving on, we should write a quick test to verify this is encoding things
 
 Let's test the function we just wrote. To keep things clean, create a new file `test/DeployMoodNftTest.t.sol`. The setup for this file is going to be the same as always.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -95,7 +95,7 @@ data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIH
 
 In our test now, we can assign an expectedUri variable to this string. We'll need to also define the svg which we'll pass to the function.
 
-```js
+```solidity
 function testConvertSvgToUri() public view {
     string memory expectedUri = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIj4KPHRleHQgeD0iMjAwIiB5PSIyNTAiIGZpbGw9ImJsYWNrIj5IaSEgWW91IGRlY29kZWQgdGhpcyEgPC90ZXh0Pgo8L3N2Zz4="
     string memory svg = '<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500"><text x="200" y="250" fill="black">Hi! You decoded this! </text></svg>'
@@ -106,7 +106,7 @@ function testConvertSvgToUri() public view {
 
 Great! Now we'll need to assert that our expectedUri is equal to our actualUri. Remember, we can't compare strings directly since they're effectively bytes arrays. We need to hash these for easy comparison.
 
-```js
+```solidity
 assert(
   keccak256(abi.encodePacked(expectedUri)) ==
     keccak256(abi.encodePacked(actualUri))
@@ -136,7 +136,7 @@ fs_permissions = [{access = "read", path = "./img/"}]
 
 With this in place, we can now use the readFile cheatcode to access these SVG files in our deploy script.
 
-```js
+```solidity
 // SPDX-License-Identifier:MIT
 pragma solidity ^0.8.18;
 
@@ -161,7 +161,7 @@ contract DeployMoodNft is Script {
 
 Now we can deploy our MoodNft.sol contract in our run function, passing it the data read in from these files.
 
-```js
+```solidity
 function run () external returns (MoodNft) {
     string memory sadSvg = vm.readFile("./img/sadSvg.svg");
     string memory happySvg = vm.readFile("./img/happySvg.svg");
@@ -189,7 +189,7 @@ We'll adjust `MoodNftIntegrationsTest.t.sol` to use our deployer next.
 
 The changes to be made in this file are fairly small, but impactful. Instead of deploying with:
 
-```js
+```solidity
 moodNft = new MoodNft(SAD_SVG_URI, HAPPY_SVG_URI);
 ```
 
@@ -198,7 +198,7 @@ We can use our newly written deployer. It'll need to be imported.
 <details>
 <summary>MoodNftIntegrationsTest.t.sol</summary>
 
-```js
+```solidity
 //SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -240,7 +240,7 @@ With these adjustments, our tests should function identically to before.
 
 One thing we definitely haven't tested yet, and we should do quickly, is our flipMood function. Lets assure this properly swaps between happy and sad when called.
 
-```js
+```solidity
 function testFlipMoodIntegration() public {
     vm.prank(USER);
     moodNFT.mintNft();

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/16-svg-debug/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/16-svg-debug/+page.md
@@ -20,7 +20,7 @@ Hmm, this gives us a little more information, detailing that our assertion faile
 
 This is where I like to employ `assertEq` instead of `assert` as this will print both the left and right sides of the assertion to our console.
 
-```js
+```solidity
 assertEq(
   keccak256(abi.encodePacked(moodNft.tokenURI(0))),
   keccak256(abi.encodePacked(SAD_SVG_URI))
@@ -37,7 +37,7 @@ forge test --mt testFlipMoodIntegration -vvv
 
 Well, our hashes are definitely different. We can import console and log out some variables to see what's going wrong.
 
-```js
+```solidity
 import {console, Test} from "forge-std/Test.sol";
 ...
 
@@ -70,7 +70,7 @@ Let's check the other side of the assertion. We have the SAD_SVG_URI as a consta
 
 Wait a minute! One of these is returning our **_tokenURI_** and the other is our **_imageURI_**! This is why it's important to be explicit in our naming conventions! Let's adjust these constants, and our test, right away. We can define a variable with what we expect the **_tokenURI_** to be and assert versus that.
 
-```js
+```solidity
 string public constant SAD_SVG_IMAGE_URI = ...;
 string public constant HAPPY_SVG_IMAGE_URI = ...;
 string public constant SAD_SVG_URI = "data:application/json;base64,eyJuYW1lIjogIkJpUG9sYXIiLCAiZGVzY3JpcHRpb24iOiAiQW4gTkZUIHRoYXQgcmVmbGVjdHMgeW91ciBtb29kISIsICJhdHRyaWJ1dGVzIjogW3sidHJhaXRfdHlwZSI6ICJNb29kIiwgInZhbHVlIjogMTAwfV0sICJpbWFnZSI6ICJkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUIzYVdSMGFEMGlNVEF5TkhCNElpQm9aV2xuYUhROUlqRXdNalJ3ZUNJZ2RtbGxkMEp2ZUQwaU1DQXdJREV3TWpRZ01UQXlOQ0lnZUcxc2JuTTlJbWgwZEhBNkx5OTNkM2N1ZHpNdWIzSm5Mekl3TURBdmMzWm5JajRLSUNBOGNHRjBhQ0JtYVd4c1BTSWpNek16SWlCa1BTSk5OVEV5SURZMFF6STJOQzQySURZMElEWTBJREkyTkM0MklEWTBJRFV4TW5NeU1EQXVOaUEwTkRnZ05EUTRJRFEwT0NBME5EZ3RNakF3TGpZZ05EUTRMVFEwT0ZNM05Ua3VOQ0EyTkNBMU1USWdOalI2YlRBZ09ESXdZeTB5TURVdU5DQXdMVE0zTWkweE5qWXVOaTB6TnpJdE16Y3ljekUyTmk0MkxUTTNNaUF6TnpJdE16Y3lJRE0zTWlBeE5qWXVOaUF6TnpJZ016Y3lMVEUyTmk0MklETTNNaTB6TnpJZ016Y3llaUl2UGdvZ0lEeHdZWFJvSUdacGJHdzlJaU5GTmtVMlJUWWlJR1E5SWswMU1USWdNVFF3WXkweU1EVXVOQ0F3TFRNM01pQXhOall1Tmkwek56SWdNemN5Y3pFMk5pNDJJRE0zTWlBek56SWdNemN5SURNM01pMHhOall1TmlBek56SXRNemN5TFRFMk5pNDJMVE0zTWkwek56SXRNemN5ZWsweU9EZ2dOREl4WVRRNExqQXhJRFE0TGpBeElEQWdNQ0F4SURrMklEQWdORGd1TURFZ05EZ3VNREVnTUNBd0lERXRPVFlnTUhwdE16YzJJREkzTW1ndE5EZ3VNV010TkM0eUlEQXROeTQ0TFRNdU1pMDRMakV0Tnk0MFF6WXdOQ0EyTXpZdU1TQTFOakl1TlNBMU9UY2dOVEV5SURVNU4zTXRPVEl1TVNBek9TNHhMVGsxTGpnZ09EZ3VObU10TGpNZ05DNHlMVE11T1NBM0xqUXRPQzR4SURjdU5FZ3pOakJoT0NBNElEQWdNQ0F4TFRndE9DNDBZelF1TkMwNE5DNHpJRGMwTGpVdE1UVXhMallnTVRZd0xURTFNUzQyY3pFMU5TNDJJRFkzTGpNZ01UWXdJREUxTVM0MllUZ2dPQ0F3SURBZ01TMDRJRGd1TkhwdE1qUXRNakkwWVRRNExqQXhJRFE0TGpBeElEQWdNQ0F4SURBdE9UWWdORGd1TURFZ05EZ3VNREVnTUNBd0lERWdNQ0E1Tm5vaUx6NEtJQ0E4Y0dGMGFDQm1hV3hzUFNJak16TXpJaUJrUFNKTk1qZzRJRFF5TVdFME9DQTBPQ0F3SURFZ01DQTVOaUF3SURRNElEUTRJREFnTVNBd0xUazJJREI2YlRJeU5DQXhNVEpqTFRnMUxqVWdNQzB4TlRVdU5pQTJOeTR6TFRFMk1DQXhOVEV1Tm1FNElEZ2dNQ0F3SURBZ09DQTRMalJvTkRndU1XTTBMaklnTUNBM0xqZ3RNeTR5SURndU1TMDNMalFnTXk0M0xUUTVMalVnTkRVdU15MDRPQzQySURrMUxqZ3RPRGd1Tm5NNU1pQXpPUzR4SURrMUxqZ2dPRGd1Tm1NdU15QTBMaklnTXk0NUlEY3VOQ0E0TGpFZ055NDBTRFkyTkdFNElEZ2dNQ0F3SURBZ09DMDRMalJETmpZM0xqWWdOakF3TGpNZ05UazNMalVnTlRNeklEVXhNaUExTXpONmJURXlPQzB4TVRKaE5EZ2dORGdnTUNBeElEQWdPVFlnTUNBME9DQTBPQ0F3SURFZ01DMDVOaUF3ZWlJdlBnbzhMM04yWno0PSJ9"

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/19-advanced-evm/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/19-advanced-evm/+page.md
@@ -21,7 +21,7 @@ Until now, we've been using abi.encode and abi.encodePacked effectively as a mea
 
 When ready, in [**Remix**](https://remix.ethereum.org), create a new file named `Encoding.sol`. We can set this contract up with some boilerplate before writing the functions we'll use to explore encoding and decoding.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -31,7 +31,7 @@ contract Encoding {}
 
 Within this contract, let's now right a simple function to concatenate two strings using `abi.encodePacked`.
 
-```js
+```solidity
 function combineStrings() public pure returns(string memory){
     return string(abi.encodePacked("Hi Mom! ", "Miss you!"));
 }
@@ -106,7 +106,7 @@ Strictly speaking, we can use abi encoding to encode anything we want into the b
 
 Lets write a function to explore this. In our Encoding.sol file, in Remix add:
 
-```js
+```solidity
 function encodeNumber() public pure returns(bytes memory){
     bytes memory number = abi.encode(1);
     return number;
@@ -124,7 +124,7 @@ This hex format, this encoding, is how a computer understands the number `1`.
 
 Now, as mentioned, this can be used to encode basically anything, we can write a function to encode a string and see what it's output would be just the same.
 
-```js
+```solidity
 function encodeString() public pure returns(string memory){
     byte memory someString = abi.encode("some string");
     return someString;
@@ -155,7 +155,7 @@ You can kind of think of encodePacked as a compressor which removed unnecessary 
 
 We can demonstrate this in Remix by adding this function, redeploying our Encoding.sol contract and calling it.
 
-```js
+```solidity
 function encodeStringPacked() public pure returns(bytes memory){
     bytes memory someString = abi.encodePacked("some string");
     return someString;
@@ -168,7 +168,7 @@ We can clearly see how much smaller the encodePacked output is, if we were tryin
 
 Encoding in this way is very similar to something else we've done before, typecasting. Add this function to Encoding.sol, and redeploy to see how these compare in practice:
 
-```js
+```solidity
 function encodeStringBytes() public pure returns(bytes memory) {
     bytes memory someString = bytes("some string");
     return someString;
@@ -187,7 +187,7 @@ From the docs we can see the decode function takes the encoded data and a tuple 
 
 ::image{src='/foundry-nfts/19-advanced-evm/advanced-evm11.png' style='width: 100%; height: auto;'}
 
-```js
+```solidity
 function decodeString() public pure returns(string memory) {
     string memory someString = abi.decode(encodeString(), (string));
     return someString;
@@ -202,7 +202,7 @@ Once again, we can add this function to our Encoding.sol contract and redeploy i
 
 To take all this one step further, this encoding functionality affords us the ability to encode as much as we want. We can demonstrate this with the following functions:
 
-```js
+```solidity
 function multiEncode() public pure returns(bytes memory){
     bytes memory someString = abi.encode("some string", "it's bigger!");
     return someString;
@@ -220,7 +220,7 @@ When we multiEncode, you can see that our output is an _even bigger_ bytes objec
 
 You probably guessed, we can **also** multiEncodePacked. Try it out with:
 
-```js
+```solidity
 function multiEncodePacked() public pure returns (bytes memory){
     bytes memory someString = abi.encodePacked("some string", "it's bigger!");
     return someString;
@@ -231,7 +231,7 @@ function multiEncodePacked() public pure returns (bytes memory){
 
 This is actually where our fun stops a little bit. Because we're packing the encoding of multiple strings, the decoding function is unable to properly split these up. It's not possible to multiDecode a multiEncodePacked object 😦. If you try something like:
 
-```js
+```solidity
 function multiDecodePacked() public pure returns (string memory, string memory){
     string memory someString = abi.decode(multiEncodePacked(), (string));
     return someString;
@@ -240,7 +240,7 @@ function multiDecodePacked() public pure returns (string memory, string memory){
 
 ... this will actually error. We do have an alternative method though.
 
-```js
+```solidity
 function multiStringCastPacked() public pure returns (string memory){
     string memory someString = string(multiEncodePacked());
     return someString;

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/20-evm-encoding/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/20-evm-encoding/+page.md
@@ -85,7 +85,7 @@ We're going to answer these by leveraging additional low-level keywords offered 
 
 We've used call previously... if this code rings a bell:
 
-```js
+```solidity
 function withdraw(address recentWinner) public {
     (bool success, ) = recentWinner.call{value: address(this).balance}("");
     require(success, "Transfer Failed");

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/21-evm-recap/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/21-evm-recap/+page.md
@@ -14,7 +14,7 @@ Before looking at how we can apply all our new encoding knowledge to call our ow
 
 At a high-level, we learnt that abi.encodePacked can be used to concatenate strings.
 
-```js
+```solidity
 string memory someString = string(abi.encodePacked("Hi Mom! ", "Miss you!"))
 ```
 

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/22-evm-signatures-selectors/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/22-evm-signatures-selectors/+page.md
@@ -28,7 +28,7 @@ When we send a call to an address, the EVM determines how to respond based on th
 
 One way we can acquire the function selector is to encode the entire function signature, and grab the first 4 bytes of the result. Let's see what this looks like in our contract.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -56,7 +56,7 @@ This is great when we already know a function selector, but..
 
 The answer is - we can write a function! There are actually a few different ways we can approach this, let's go through them.
 
-```js
+```solidity
 function getSelectorOne() public pure returns(bytes4 selector){
     selector = bytes4(keccak256(bytes("transfer(address,uint256)")));
 }
@@ -74,7 +74,7 @@ Much like abi.encode and abi.encodePacked, the EVM offers us a way to encode our
 
 We can write another function to compile this data for our function call for us.
 
-```js
+```solidity
 function getDataToCallTransfer(address someAddress, uint256 amount) public pure returns(bytes memory){
     return abi.encodeWithSelector(getSelectorOne(), someAddress, amount);
 }
@@ -88,7 +88,7 @@ If we compile CallAnything.sol and redeploy in Remix, we can call this function 
 
 This is the data we would need to pass a low-level `call` in order to call the transfer function with our given parameters. We can now write a function that uses this data to make the function call.
 
-```js
+```solidity
 function callTransferWithBinary(address someAddress, uint256 amount) public returns(bytes4, bool){
     (bool success, bytes memory returnData) = address(this).call(abi.encodeWithSelector(getSelectorOne(), someAddress, amount));
 }
@@ -105,7 +105,7 @@ In the above we're sending our function call to the contract's own address, but 
 
 Typically we'd see something requiring success to be true, but for our example we'll just have our function return these values.
 
-```js
+```solidity
 function callTransferWithBinary(address someAddress, uint256 amount) public returns(bytes4, bool){
     (bool success, bytes memory returnData) = address(this).call(abi.encodeWithSelector(getSelectorOne(), someAddress, amount));
 
@@ -136,7 +136,7 @@ With this transaction complete, we should be able to repoll the storage variable
 
 ...and they are! Amazing! Another option Solidity affords us is the ability to encode with a signature. This effectively saves us a step since we don't have to determine the function selector first.
 
-```js
+```solidity
 function callTransferWithBinarySignature(address someAddress, uint256 amount) public returns(bytes4, bool){
     (bool success, bytes memory returnData) = address(this).call(abi.encodeWithSignature("transfer(address,uint256)", someAddress, amount));
 
@@ -154,7 +154,7 @@ We wont walk through all the different methods here, but I've provided some of t
 
 CallAnything.sol
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 // So why do we care about all this encoding stuff?
@@ -251,7 +251,7 @@ One last thing I want to point out is that we're not limited to this kind of int
 
 CallFunctionWithoutContract
 
-```js
+```solidity
 contract CallFunctionWithoutContract {
     address public s_selectorsAndSignaturesAddress;
 

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/5-using-ipfs/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/5-using-ipfs/+page.md
@@ -86,7 +86,7 @@ If you view this in your browser or through the IPFS Desktop App, you should see
 
 Now, we could just paste the about tokenURI as a return value of our tokenUri function, but this would mint every Doggie identical to each other. Let's spice things up a little bit and allow the user to choose what their NFT looks like. We'll do this by allowing the user to pass a tokenUri to the mint function and mapping this URI to their minted tokenId.
 
-```js
+```solidity
 contract BasicNFT is ERC721 {
     uint256 private s_tokenCounter;
     mapping(uint256 => string) private s_tokenIdToUri;
@@ -109,7 +109,7 @@ contract BasicNFT is ERC721 {
 
 Great! All that's missing is to mint the NFT and increment our token counter. We can mint the token by calling the inherited \_safeMint function.
 
-```js
+```solidity
 contract BasicNFT is ERC721 {
     uint256 private s_tokenCounter;
     mapping(uint256 => string) private s_tokenIdToUri;

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/6-deploy-script/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/6-deploy-script/+page.md
@@ -10,7 +10,7 @@ _Follow along the course with this video._
 
 The muscle memory should be kicking in for some of these deploy scripts by now. Let's not waste any time setting this one up! Create a new file `script/DeployBasicNft.s.sol`.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/7-basic-nft-tests/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/7-basic-nft-tests/+page.md
@@ -12,7 +12,7 @@ Once the setup is complete, it's time to jump into tests. Writing an array of te
 
 Start with the usual boilerplate for our test contract. Create the file `test/BasicNftTest.t.sol`. Our test contract will need to import BasicNft, and our deploy script as well as import and inherit Foundry's `Test.sol`.
 
-```js
+```solidity
 //SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -34,7 +34,7 @@ contract BasicNFTTest is Test {
 
 To confirm that the Name of your NFT is correct, declare a function `testNameIsCorrect` and specify it as public view.
 
-```js
+```solidity
 function testNameIsCorrect() public view {
   string memory expected = "Doggie";
   string memory actual = basicNft.name();
@@ -82,7 +82,7 @@ We'll leverage abi.encodePacked to convert this to bytes, then finally we can us
 
 If we apply this encoding and hashing methodology to our BasicNft test, we should come out with something that looks like this:
 
-```js
+```solidity
 function testNameIsCorrect() public view {
   string memory expectedName = "Doggie";
   string memory actualName = basicNft.name();
@@ -101,7 +101,7 @@ Great work! Let's write a couple more tests together.
 
 The next test we write will assure a user can mint the NFT and then change the user's balance. We'll need to create a user to prank in our test. Additionally, we'll need to provide our mint function a tokenUri, I've provided one below for convenience. If you've one prepared from the previous lesson, feel free to use it!
 
-```js
+```solidity
 contract BasicNftTest is Test {
   ...
   address public USER = makeAddr("user");

--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/8-basic-interactions/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/8-basic-interactions/+page.md
@@ -10,7 +10,7 @@ _Follow along the course with this video._
 
 Alright, with our tests passing we're going to want a way to interact with our contract programmatically. We could use `cast` commands, but let's write an interactions script instead. Create the file `script/Interactions.s.sol`. You know the drill for our boilerplate by now.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -33,7 +33,7 @@ Now, we can import `DevOpsTools` and use this to acquire our most recent deploym
 > ❗ **NOTE**
 > I've copied over my `PUG tokenUri` for use in our `mint` function, remember to copy your own over too!
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;

--- a/courses/advanced-foundry/3-develop-defi-protocol/11-defi-tests/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/11-defi-tests/+page.md
@@ -14,7 +14,7 @@ In the last lesson, we set up a deploy script as well as a `HelperConfig` to ass
 
 Create `test/unit/DSCEngine.t.sol` and begin with the boilerplate we're used to. We know we'll have to import our deploy script as well as `Test`, `DecentralizedStableCoin.sol`, and `DSCEngine.sol`.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -31,7 +31,7 @@ contract DSCEngineTest is Test {
 
 Declare our contract/script variables, then in our `setUp` function, we're going to need to deploy our contracts using our `DeployDSC` script.
 
-```js
+```solidity
 contract DSCEngineTest is Test {
     DeployDSC deployer;
     DecentralizedStableCoin dsc;
@@ -46,7 +46,7 @@ contract DSCEngineTest is Test {
 
 I think a good place to start will be checking some of our math in `DSCEngine`. We should verify that we're pulling data from our price feeds properly and that our USD calculations are correct.
 
-```js
+```solidity
 /////////////////
 // Price Tests //
 /////////////////
@@ -56,7 +56,7 @@ function testGetUsdValue() public {}
 
 The `getUsdValue` function takes a token address and an amount as a parameter. We could import our mocks for reference here, but instead, let's adjust our `DeployDSC` script to also return our `HelperConfig`. We can acquire these token addresses from this in our test.
 
-```js
+```solidity
 contract DeployDSC is Script {
     ...
 
@@ -85,7 +85,7 @@ Now, back to our test. We'll need to do a few things in `DSCEngineTest.t.sol`.
 - Acquire the imported config from our `deployer.run` call
 - Acquire `ethUsdPriceFeed` and weth from our `config`'s `activeNetworkConfig`
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -114,7 +114,7 @@ contract DSCEngineTest is Test {
 
 We're now ready to use some of these values in our test function. For our unit test, we'll be requesting the value of `15ETH`, or `15e18`. Our HelperConfig has the ETH/USD price configured at `$2000`. Thus we should expect `30000e18` as a return value from our getUsdValue function. Let's see if that's true.
 
-```js
+```solidity
 /////////////////
 // Price Tests //
 /////////////////
@@ -140,7 +140,7 @@ It works! We're clearly still on track. This is great. It's good practice to tes
 
 Before moving on, we should write a test for our `depositCollateral` function as well. We'll need to import our `ERC20Mock` in order to test deposits, so let's do that now. We'll also need to declare a `USER` to call these functions with and amount for them to deposit.
 
-```js
+```solidity
 import {ERC20Mock} from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
 
 ...
@@ -164,7 +164,7 @@ contract DSCEngineTest is Test {
 
 Let's make sure our `USER` has some tokens minted to them in our `setUp`, they'll need them for several tests in our future.
 
-```js
+```solidity
 address public USER = makeAddr("user");
 uint256 public constant AMOUNT_COLLATERAL = 10 ether;
 uint256 public constant STARTING_ERC20_BALANCE = 10 ether;
@@ -180,7 +180,7 @@ function setUp public {
 
 Our user is going to need to approve the `DSCEngine` contract to call `depositCollateral`. Despite this, we're going to deposit `0`. This _should_ cause our function call to revert with our custom error `DSCEngine__NeedsMoreThanZero`, which we'll account for with `vm.expectRevert`.
 
-```js
+```solidity
  /////////////////////////////
 // depositCollateral Tests //
 /////////////////////////////

--- a/courses/advanced-foundry/3-develop-defi-protocol/12-defi-deposit-and-mint/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/12-defi-deposit-and-mint/+page.md
@@ -13,7 +13,7 @@ Our current DSCEngine.sol for reference:
 <details>
 <summary>DSCEngine.sol</summary>
 
-```js
+```solidity
 // Layout of Contract:
 // version
 // imports
@@ -244,7 +244,7 @@ The next thing I want to tackle is sort of the main function we'd expect in this
 
 The parameters for our depositCollateralAndMintDsc function are going to be similar to what we've seen in depositCollateral.
 
-```js
+```solidity
 function depositCollateralAndMintDsc(address tokenCollateralAddress, uint256 amountCollateral, uint256 amountDscToMint){}
 ```
 
@@ -255,7 +255,7 @@ All we really need to do, in this function, is call our depositCollateral and mi
 
 Because this is one of our main functions, we're absolutely going to add some NATSPEC.
 
-```js
+```solidity
 /*
  * @param tokenCollateralAddress: the address of the token to deposit as collateral
  * @param amountCollateral: The amount of collateral to deposit

--- a/courses/advanced-foundry/3-develop-defi-protocol/14-defi-liquidation-setup/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/14-defi-liquidation-setup/+page.md
@@ -11,7 +11,7 @@ Our current DSCEngine.sol for reference:
 <details>
 <summary>DSCEngine.sol</summary>
 
-```js
+```solidity
 // Layout of Contract:
 // version
 // imports
@@ -281,7 +281,7 @@ contract DSCEngine is ReentrancyGuard {
 
 Our `DSCEngine` is almost done! We've got a couple more functions to flesh out still.
 
-```js
+```solidity
 function liquidate() external {}
 
 function getHealthFactor() external view {}
@@ -303,7 +303,7 @@ To illustrate:
 
 Let's write this out.
 
-```js
+```solidity
 /*
 * @param collateral: The ERC20 token address of the collateral you're using to make the protocol solvent again.
 * This is collateral that you're going to take from the user who is insolvent.
@@ -326,7 +326,7 @@ As such an important function to the protocol we've made every effort to be as c
 
 Alright, let's keep going. The first thing we'll want to do in `liquidate` is verify that the passed user is eligible for liquidation. Someone being liquidated should have a `Health Factor` below `1`, otherwise this function should revert.
 
-```js
+```solidity
 function liquidate(address collateral, address user, uint256 debtToCover) external moreThanZero(debtToCover) nonReentrant {
     uint256 startingUserHealthFactor = _healthFactor(user);
     if(startingUserHealthFactor > MIN_HEALTH_FACTOR){
@@ -337,7 +337,7 @@ function liquidate(address collateral, address user, uint256 debtToCover) extern
 
 Of course, we'll add our error to the errors section at the top of our contract.
 
-```js
+```solidity
 ///////////////////
 //     Errors    //
 ///////////////////
@@ -360,7 +360,7 @@ Our next step in the `liquidate` function is to remove the unhealthy position fr
 
 We'll need a new function to calculate this token amount, but we'll get to that next.
 
-```js
+```solidity
 function liquidate(address collateral, address user, uint256 debtToCover) external moreThanZero(debtToCover) nonReentrant {
     uint256 startingUserHealthFactor = _healthFactor(user);
     if(startingUserHealthFactor > MIN_HEALTH_FACTOR){
@@ -373,7 +373,7 @@ function liquidate(address collateral, address user, uint256 debtToCover) extern
 
 We're passing the `getTokenAmountFromUsd` function the type of collateral, and the amount of debt we're covering. From this we'll be able to use price feeds to determine how much of the given collateral should be redeemed. This will be another public/external view function.
 
-```js
+```solidity
 //////////////////////////////////////////
 //   Public & External View Functions   //
 //////////////////////////////////////////
@@ -390,7 +390,7 @@ Remember, we multiply by `PRECISION(1e18)` and `ADDITIONAL_FEED_PRECISION (1e10)
 
 Next, let's ensure the `liquidator` is being incentivized for securing the protocol, we'll configure a `10%` bonus to the collateral awarded to the `liquidator`.
 
-```js
+```solidity
 function liquidate(address collateral, address user, uint256 debtToCover) external moreThanZero(debtToCover) nonReentrant {
     uint256 startingUserHealthFactor = _healthFactor(user);
     if(startingUserHealthFactor > MIN_HEALTH_FACTOR){
@@ -405,7 +405,7 @@ function liquidate(address collateral, address user, uint256 debtToCover) extern
 
 Be sure to declare our new constant state variable, `LIQUIDATION_BONUS`. By setting this to `10` and dividing by our `LIQUIDATION_PRECISION` of `100`, we're setting a `10%` collateral bonus.
 
-```js
+```solidity
 /////////////////////////
 //   State Variables   //
 /////////////////////////
@@ -415,7 +415,7 @@ uint256 private constant LIQUIDATION_BONUS = 10;
 
 We then of course add this bonus to our current `tokenAmountFromDebtCovered`, to acquire the total collateral being redeemed.
 
-```js
+```solidity
 function liquidate(address collateral, address user, uint256 debtToCover) external moreThanZero(debtToCover) nonReentrant {
     uint256 startingUserHealthFactor = _healthFactor(user);
     if(startingUserHealthFactor > MIN_HEALTH_FACTOR){

--- a/courses/advanced-foundry/3-develop-defi-protocol/15-defi-liquidation-refactor/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/15-defi-liquidation-refactor/+page.md
@@ -11,7 +11,7 @@ Our current DSCEngine.sol for reference:
 <details>
 <summary>DSCEngine.sol</summary>
 
-```js
+```solidity
 // Layout of Contract:
 // version
 // imports
@@ -315,7 +315,7 @@ contract DSCEngine is ReentrancyGuard {
 
 In the last lesson we left off with our `liquidate` function still needing to redeem the unhealthy position's collateral, and burn the `liquidator`'s `DSC`. If we look at the `redeemCollateral` function, we can see why achieving our goal won't be as simple as calling `redeemCollateral` and `burnDsc`.
 
-```js
+```solidity
 function redeemCollateral(address tokenCollateralAddress, uint256 amountCollateral) public moreThanZero(amountCollateral) nonReentrant{
     s_collateralDeposited[msg.sender][tokenCollateralAddress] -= amountCollateral;
     emit CollateralRedeemed(msg.sender, tokenCollateralAddress, amountCollateral);
@@ -335,7 +335,7 @@ What we'll do is refactor the contract to include an _internal_ `_redeemCollater
 
 We'll add this new internal function under our `Private & Internal View Functions` header.
 
-```js
+```solidity
 ///////////////////////////////////////////
 //   Private & Internal View Functions   //
 ///////////////////////////////////////////
@@ -355,7 +355,7 @@ The above internal version of `redeemCollateral` contains the same logic as our 
 
 At this point let's adjust our `CollateralRedeemed` event. We're going to adjust the emission and the declaration of the event to handle this new from/to structure. We'll adjust this in our public `redeemCollateral` function soon.
 
-```js
+```solidity
 ////////////////
 //   Events   //
 ////////////////
@@ -377,7 +377,7 @@ function _redeemCollateral(address tokenCollateralAddress, uint256 amountCollate
 
 Now, back in our public `redeemCollateral` function, we can simply call this internal version and hardcode the appropriate `msg.sender` values.
 
-```js
+```solidity
 function redeemCollateral(address tokenCollateralAddress, uint256 amountCollateral) public moreThanZero(amountCollateral) nonReentrant{
     _redeemCollateral(msg.sender, msg.sender, tokenCollateralAddress, amountCollateral);
     _revertIfHealthFactorIsBroken(msg.sender);
@@ -388,7 +388,7 @@ function redeemCollateral(address tokenCollateralAddress, uint256 amountCollater
 
 Now that we've written this internal `_redeemCollateral` function, we can leverage this within our `liquidate` function.
 
-```js
+```solidity
 function liquidate(address collateral, address user, uint256 debtToCover) external moreThanZero(debtToCover) nonReentrant {
     uint256 startingUserHealthFactor = _healthFactor(user);
     if(startingUserHealthFactor > MIN_HEALTH_FACTOR){
@@ -406,7 +406,7 @@ function liquidate(address collateral, address user, uint256 debtToCover) extern
 
 With the refactoring we've just done, we can be sure that the `liquidator` will be awarded the collateral (after some testing of course). We're going to need to do the same thing with our `burnDsc` function, which is currently public and hardcoded with `msg.sender` as well.
 
-```js
+```solidity
 function burnDsc(uint256 amount) public moreThanZero(amount){
     _burnDsc(amount, msg.sender, msg.sender)
     _revertIfHealthFactorIsBroken(msg.sender);
@@ -426,7 +426,7 @@ function _burnDsc(uint256 amountDscToBurn, address onBehalfOf, address dscFrom) 
 
 And, just like before, we can go back to our `liquidate` function and leverage this internal `_burnDsc`.
 
-```js
+```solidity
 function liquidate(address collateral, address user, uint256 debtToCover) external moreThanZero(debtToCover) nonReentrant {
     uint256 startingUserHealthFactor = _healthFactor(user);
     if(startingUserHealthFactor > MIN_HEALTH_FACTOR){
@@ -446,7 +446,7 @@ function liquidate(address collateral, address user, uint256 debtToCover) extern
 
 Importantly, we're calling these low level internal calls, so we've going to want to check some `Health Factors` here. If the `liquidation` somehow doesn't result in the user's `Health Factor` improving, we should revert. This will come with a new custom error.
 
-```js
+```solidity
 uint256 endingUserHealthFactor = _healthFactor(user);
 if(endingUserHealthFactor <= startingUserHealthFactor){
     revert DSCEngine__HealthFactorNotImproved();
@@ -455,7 +455,7 @@ if(endingUserHealthFactor <= startingUserHealthFactor){
 
 Be sure to declare the custom error where appropriate.
 
-```js
+```solidity
 ///////////////////
 //     Errors    //
 ///////////////////
@@ -467,7 +467,7 @@ error DSCEngine__HealthFactorNotImproved();
 
 The last thing we'll want to do is also ensure that our `liquidator`'s `Health Factor` hasn't been broken. Our final `liquidate` function should look like this:
 
-```js
+```solidity
 function liquidate(address collateral, address user, uint256 debtToCover) external moreThanZero(debtToCover) nonReentrant {
     uint256 startingUserHealthFactor = _healthFactor(user);
     if(startingUserHealthFactor > MIN_HEALTH_FACTOR){

--- a/courses/advanced-foundry/3-develop-defi-protocol/16-defi-leveling-up-testing/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/16-defi-leveling-up-testing/+page.md
@@ -21,7 +21,7 @@ These are the _bare minimum_ of testing in Web3 security. Unit test will propose
 
 For example, take the contract below.
 
-```js
+```solidity
 // SPDX-License-Identifier
 pragma solidity ^0.8.13;
 
@@ -36,7 +36,7 @@ contract CaughtWithTest {
 
 In a situation like this, if the expectation was that `number` is being set to `newNumber`, a unit test would catch this. In our unit test, we would assert our expected outcome and pass a test value to our function:
 
-```js
+```solidity
 function testSetNumber() public {
     uint256 myNumber = 55;
     caughtWithTest.setNumber(myNumber);
@@ -58,7 +58,7 @@ An invariant is a property of a protocol which much always hold true. Fuzz testi
 
 Consider a slightly more complex contract such as below.
 
-```js
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -78,7 +78,7 @@ In this simple example, we can easily see that if we pass `2` as an argument to 
 
 Here's an example of a fuzz test we could perform:
 
-```js
+```solidity
     ...
     function testIAlwaysGetZeroFuzz(uint256 data) public {
         myContract.doStuff(data);
@@ -96,7 +96,7 @@ Unit testing and fuzz testing as examples of **_dynamic tests_**, this is when c
 
 Alternatively to this, we have static analysis as a tool available to us. In static analysis testing, a tool such as [**Slither**](https://github.com/crytic/slither) or [**Aderyn**](https://github.com/Cyfrin/aderyn), will review the code and identify vulnerabilities based on things like layout, ordering and syntax.
 
-```js
+```solidity
 function withdraw() external {
     uint256 balance = balances[msg.sender];
     require(balance > 0);
@@ -124,7 +124,7 @@ We'll only really cover Symbolic Execution in this course. If you want to dive d
 
 At a high-level, Symbolic Execution models each path in the code mathematically to identify if any path results in the breaking of an asserted property of the system.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 

--- a/courses/advanced-foundry/3-develop-defi-protocol/17-defi-handler-fuzz-tests/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/17-defi-handler-fuzz-tests/+page.md
@@ -23,7 +23,7 @@ So that we're all on the same page, I suggest taking a look at the GitHub Repo f
 
 One example of an addition made is the internal \_calculateHealthFactor function and the public equivalent calculateHealthFactor. These functions allow us to access expected Health Factors in our tests.
 
-```js
+```solidity
 uint256 expectedHealthFactor =
 dsce.calculateHealthFactor(amountToMint, dsce.getUsdValue(weth, amountCollateral));
 vm.expectRevert(abi.encodeWithSelector(DSCEngine.DSCEngine__BreaksHealthFactor.selector, expectedHealthFactor));
@@ -37,7 +37,7 @@ Did you find it?
 
 The issue was found in how we calculated our Health Factor originally.
 
-```js
+```solidity
 function _healthFactor(address user) private view returns(uint256){
     (uint256 totalDscMinted, uint256 collateralValueInUsd) = _getAccountInformation(user);
 
@@ -49,7 +49,7 @@ function _healthFactor(address user) private view returns(uint256){
 
 In the above, we need to account for when a user has deposited collateral, but hasn't minted DSC. In this circumstance our return value is going to be dividing by zero! Obviously not good, so what we do is account for this with a conditional, if a user's minted DSC == 0, we just set their Health Factor to a massive positive number and return that.
 
-```js
+```solidity
 function _calculateHealthFactor(uint256 totalDscMinted, uint256 collateralValueInUsd)
     internal
     pure
@@ -68,7 +68,7 @@ The last major change in the repo since our last lesson is the addition to a num
 <details>
 <summary>View Functions</summary>
 
-```js
+```solidity
 function getPrecision() external pure returns (uint256) {
     return PRECISION;
 }
@@ -126,7 +126,7 @@ Let's detail Fuzz Testing at a high-level before diving into it's application.
 
 Fuzz Testing is when you supply random data to a system in an attempt to break it. If you recall the example used in a previous lesson:
 
-```js
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -146,7 +146,7 @@ In the above `shouldAlwaysBeZero` == 0 is our `invariant`, the property of our s
 
 Simple unit test for the above might look something like:
 
-```js
+```solidity
 function testIAlwaysGetZero() public {
     uint256 data = 0;
     myContract.doStuff(data);
@@ -158,7 +158,7 @@ The limitation of the above should be clear, we would have the assign data to ev
 
 Instead we invoke fuzz testing by making a few small changes to the test syntax.
 
-```js
+```solidity
 function testIAlwaysGetZero(uint256 data) public {
     myContract.doStuff(data);
     assert(myContract.shouldAlwaysBeZero() == 0);
@@ -188,7 +188,7 @@ runs = 1000
 
 Now, if we adjust our example function...
 
-```js
+```solidity
 function doStuff(uint256 data) public {
     // if (data == 2){
     //     shouldAlwaysBeZero = 1;
@@ -208,7 +208,7 @@ Let's look at an example where the fuzz testing we've discussed so far will fail
 
 Take the following contract for example:
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
@@ -238,7 +238,7 @@ Stateful Fuzzing allows us to configure tests wherein the ending state of one ru
 
 In order to run stateful fuzz testing in Foundry, it requires a little bit of setup. First, we need to import StdInvariant.sol and have our contract inherit this.
 
-```js
+```solidity
 // SPDX-License-Identifier: None
 pragma solidity ^0.8.13;
 
@@ -257,7 +257,7 @@ contract MyContractTest is StdInvariant, Test {
 
 The next step is, we need to set a target contract. This will be the contract Foundry calls random functions on. We can do this by calling targetContract in our setUp function.
 
-```js
+```solidity
 contract NFT721Test is StdInvariant, Test {
     CaughtWithTest myContract;
 
@@ -270,7 +270,7 @@ contract NFT721Test is StdInvariant, Test {
 
 Finally, we just need to write our invariant, we must use the keywords invariant, or fuzz to begin this function name, but otherwise, we only need to declare our assertion, super simple.
 
-```js
+```solidity
 function invariant_testAlwaysReturnsZero() public view {
     assert(myContract.shouldAlwaysBeZero() == 0);
 }

--- a/courses/advanced-foundry/3-develop-defi-protocol/18-defi-handler-stateful-fuzz-tests/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/18-defi-handler-stateful-fuzz-tests/+page.md
@@ -20,7 +20,7 @@ Larger protocols will have so many functions available to them that it's importa
 
 In the example provided by the Foundry Docs, we can see how the functionality of the deposit function can be fine tuned to assure that approvals and mints always occur before deposit is actually called.
 
-```js
+```solidity
 function deposit(uint256 assets) public virtual {
     asset.mint(address(this), assets);
 
@@ -73,7 +73,7 @@ I challenge you to think of more, but these are going to be the two simple invar
 
 This file will be setup like any other test file to start, we've lots of practice here.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity 0.8.18;
@@ -88,7 +88,7 @@ StdInvariant is quite important for our purposes, this is where we derive the ab
 
 Again, just like the tests we've written so far, we're going to begin with a `setUp` function. In this setUp we'll perform our usual deployments of our needed contracts via our deployment script. We'll import our `HelperConfig` as well.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity 0.8.18;
@@ -117,7 +117,7 @@ From this point, it's very easy for us to wrap this up quickly with an Open Test
 
 In order to test the invariant that our collateral value must always be more than our total supply, we can leverage our `HelperConfig` to acquire the collateral addresses, and check the total balance of each collateral type within the protocol. That would look something like this (don't forget to import your `IERC20 interface` for these tokens):
 
-```js
+```solidity
 ...
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 ...
@@ -146,7 +146,7 @@ contract InvariantsTest is StdInvariant, Test {
 
 To this point our test function is only acquiring the balanced of our collateral tokens, we'll need to convert this to it's USD value for a sound comparison to our DSC total supply. We can do this with our `getUsdValue` function!
 
-```js
+```solidity
 function invariant_protocolMustHaveMoreValueThanTotalSupply() public view {
     uint256 totalSupply = dsc.totalSupply();
     uint256 totalWethDeposited = IERC20(weth).balanceOf(address(dsce));
@@ -159,7 +159,7 @@ function invariant_protocolMustHaveMoreValueThanTotalSupply() public view {
 
 And now, all we would need to do is add our assertion.
 
-```js
+```solidity
 assert(wethValue + wbtcValue > totalSupply);
 ```
 
@@ -176,7 +176,7 @@ forge test --mt invariant_protocolMustHaveMoreValueThanTotalSupply -vvvv
 
 Our test identified a break in our assertion immediately.. but it's because we have no tokens or collateral. We can adjust our assertion to be `>=`, but it's a little bit cheaty.
 
-```js
+```solidity
 assert(wethValue + wbtcValue >= totalSupply);
 ```
 

--- a/courses/advanced-foundry/3-develop-defi-protocol/20-defi-handler-redeem-collateral/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/20-defi-handler-redeem-collateral/+page.md
@@ -10,7 +10,7 @@ _Follow along the course with this video._
 
 Now that we've the means to depositCollateral in our tests, let's write the function to do the opposite, redeemCollateral. We're going to set this up similarly to our depositCollateral function within `Handler.t.sol`.
 
-```js
+```solidity
 function redeemCollateral(uint256 collateralSeed, uint256 amountCollateral) public {
     ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
 }
@@ -18,7 +18,7 @@ function redeemCollateral(uint256 collateralSeed, uint256 amountCollateral) publ
 
 Just like we bound the amountCollateral in our depositCollateral function, we'll need to do so here as well, but this time, the amount needs to be bound to the amount of collateral a user actually has! I added another getter function we can use for this.
 
-```js
+```solidity
 function redeemCollateral(uint256 collateralSeed, uint256 amountCollateral) public {
     ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
     uint256 maxCollateralToRedeem = dsce.getCollateralBalanceOfUser(address(collateral), msg.sender);
@@ -41,7 +41,7 @@ Uh oh, it looks like we're running into an issue when the maxCollateralToRedeem 
 
 We'll set the lower bounds of our `bound` function to `0`, additionally we'll add a conditional which will return if the `maxCollateralToRedeem == 0`.
 
-```js
+```solidity
 function redeemCollateral(uint256 collateralSeed, uint256 amountCollateral) public {
     ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
     uint256 maxCollateralToRedeem = dsce.getCollateralBalanceOfUser(address(collateral), msg.sender);
@@ -73,7 +73,7 @@ In our previous parts, we discussed the concepts of fuzz testing our `depositCol
 
 Our `mintDsc()` function within `DSCEngine.sol` takes a `uint256 amount`. So our handler test will do the same, we also have to restrict our handler function to avoid reverts! Our `mintDsc()` function currently requires that `amount` not be equal to zero, and that the amount minted, does not break the user's `Health Factor`. Let's look at how this handler function is built:
 
-```js
+```solidity
 ...
 contract Handler is Test {
     ...
@@ -86,13 +86,13 @@ contract Handler is Test {
 
 The above handler function ensures we're minting a random amount of DSC. But, there's a catch, we can't just let "amount" be an undefined value. It can't be zero, and the user should ideally have a stable health factor.
 
-```js
+```solidity
 amount = bound(amountDsc, 1, MAX_DEPOSIT_SIZE);
 ```
 
 This adjustment makes sure the "amount" sits in between 1 and the maximum deposit size. Now let's make sure we aren't breaking the user's `Health Factor` with this call. We can do this by calling the `getAccountInformation()` function and checking what's returned with what the user is trying to mint:
 
-```js
+```solidity
 ...
 contract Handler is Test {
     ...

--- a/courses/advanced-foundry/3-develop-defi-protocol/21-defi-handler-mint-dsc/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/21-defi-handler-mint-dsc/+page.md
@@ -12,13 +12,13 @@ In the last lesson our stateful fuzz tests were looking great, _but_ the validit
 
 Let's change that now by writing a mintDsc function for our Handler.
 
-```js
+```solidity
 function mintDsc(uint256 amount) public {}
 ```
 
 To constrain our tests, there are a couple things to consider. Namely, we know the `amount` argument needs to be greater than zero or this function will revert with `DSCEngine__NeedsMoreThanZero`. So let's account for that by binding this value.
 
-```js
+```solidity
 function mintDsc(uint256 amount) public {
     amount = bound(amount, 1, MAX_DEPOSIT_SIZE);
     vm.startPrank(msg.sender);
@@ -48,7 +48,7 @@ Ok, so things work when we have `fail_on_revert` set to `false`. We want our tes
 
 As expected, our user's Health Factor is breaking. This is because we haven't considered _who_ is minting our DSC with respect to who has deposited collateral. We can account for this in our test by ensuring that the user doesn't attempt to mint more than the collateral they have deposited, otherwise we'll return out of the function. We'll determine the user's amount to mint by calling our `getAccountInformation` function.
 
-```js
+```solidity
 function mintDsc(uint256 amount) public {
     (uint256 totalDscMinted, uint256 collateralValueInUsd) = dsce.getAccountInformation(msg.sender);
 

--- a/courses/advanced-foundry/3-develop-defi-protocol/22-defi-fuzz-debugging/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/22-defi-fuzz-debugging/+page.md
@@ -14,7 +14,7 @@ Let's start by debugging this issue. One way we attempt to figure out what's hap
 
 Ghost variables are declared in our handler and essentially function like state variables for our tests. Something we can do then, is declare `timesMintIsCalled` and have this increment within our mintDsc function.
 
-```js
+```solidity
 contract Handler is Test {
     ...
     uint256 timesMintCalled;
@@ -43,7 +43,7 @@ contract Handler is Test {
 
 With our ghost variable in place, we can now access this in our invariant test and console it out to glean some insight.
 
-```js
+```solidity
 function invariant_ProtocolTotalSupplyLessThanCollateralValue() external view returns (bool) {
     uint256 totalSupply = dsc.totalSupply();
     uint256 totalWethDeposited = IERC20(weth).balanceOf(address(dsce));
@@ -85,7 +85,7 @@ When our fuzzer is running, it's going to make random function calls, but it als
 
 In order to mitigate this issue, we'll need to track the address which deposit collateral, and then have the address calling mintDsc derived from those tracked addresses. Let's declare an address array to which addresses that have deposited collateral can be added.
 
-```js
+```solidity
 contract Handler is Test {
     ...
     uint256 timesMintIsCalled;
@@ -108,7 +108,7 @@ contract Handler is Test {
 
 This new array of addresses with collateral can now be used as a seed within our mintDsc function, much like the collateralSeed in depositCollateral.
 
-```js
+```solidity
 function mintDsc(uint256 amount, uint256 addressSeed) public {
     address sender = usersWithCollateralDeposited[addressSeed % usersWithCollateralDeposited.length]
     (uint256 totalDscMinted, uint256 collateralValueInUsd) = engine.getAccountInformation(sender);
@@ -141,7 +141,7 @@ forge test --mt invariant_ProtocolTotalSupplyLessThanCollateralValue -vvvv
 
 A new error! New errors mean progress. It seems as though our mintDsc function is causing a `division or modulo by 0`. Ah, this is because our new array of usersWithCollateralDeposited may be empty. Let's account for this with a conditional.
 
-```js
+```solidity
 function mintDsc(uint256 amount, uint256 addressSeed) public {
 
     if(usersWithCollateralDeposited.length == 0){

--- a/courses/advanced-foundry/3-develop-defi-protocol/23-defi-handler-price-feed/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/23-defi-handler-price-feed/+page.md
@@ -14,13 +14,13 @@ Take price feeds for example. These are external references that our protocol de
 
 Our project should already contain a MockV3Aggregator within the mocks folder, so let's begin by importing it into Handler.t.sol. This file mimics the behaviour of a price feed.
 
-```js
+```solidity
 import { MockV3Aggregator } from "../mocks/MockV3Aggregator.sol";
 ```
 
 Then, we can declare a state variable, and in our constructor, we can employ another getter function to acquire the price feed for that token.
 
-```js
+```solidity
 contract Handler is Test {
     ...
     MockV3Aggregator public ethUsdPriceFeed;
@@ -41,7 +41,7 @@ contract Handler is Test {
 
 With this price feed, we can not write a new function which, when called, will update the collateral price, making the calls to our protocol much more dynamic.
 
-```js
+```solidity
 function updateCollateralPrice(uint96 newPrice) public {
     int256 newPriceInt = int256(uint256(newPrice));
     ethUsdPriceFeed.updateAnswer(newPriceInt);
@@ -74,7 +74,7 @@ These are the types of scenarios that invariant tests are incredible at spotting
 
 For now, I'm going to comment out our updateCollateralPrice function. So that it won't affect our future tests.
 
-```js
+```solidity
 // THIS BREAKS OUR INVARIANT TEST SUITE!!!
 // function updateCollateralPrice(uint96 newPrice) public {
 //     int256 newPriceInt = int256(uint256(newPrice));

--- a/courses/advanced-foundry/3-develop-defi-protocol/24-defi-oracle-lib/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/24-defi-oracle-lib/+page.md
@@ -18,7 +18,7 @@ Taking a look at the [**Chainlink price feeds**](https://docs.chain.link/data-fe
 
 In our `OracleLib`, let's write some checks to ensure the prices `DSCEngine` are using aren't `stale`. If prices being received by our protocol become stale, we hope to pause the functionality of our contract.
 
-```js
+```solidity
 //SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -38,7 +38,7 @@ library OracleLib {
 
 With our _beautiful_ `NATSPEC` in place detailing the `library` and its purposes, our main function here is going to be `stalePriceCheck`. Since we'll be checking `Chainlink's price feeds`, we know we'll need the `AggregatorV3Interface`, lets be sure to import that. The return types of our function are going to be those of the `latestRoundData` function within `AggregatorV3Interface`. Let's start by getting those values.
 
-```js
+```solidity
 ...
 import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 ...
@@ -55,7 +55,7 @@ Now, we just need to calculate the time since the last update, and if it's over 
 >
 > `3 hours` == `3 * 60 * 60` == `10800 seconds`.
 
-```js
+```solidity
 ...
 import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 ...
@@ -79,7 +79,7 @@ We should now be able to use this `library` for `AggregatorV3Interfaces` to auto
 
 In `DSCEngine.sol`, we can import `OracleLib`, as our using statement under a new types header, and then replace all our calls to `latestRoundData` with `staleCheckLatestRoundData`.
 
-```js
+```solidity
 ...
 import {OracleLib} from "./libraries/OracleLib.sol";
 ...

--- a/courses/advanced-foundry/3-develop-defi-protocol/4-defi-decentralized-stablecoin/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/4-defi-decentralized-stablecoin/+page.md
@@ -52,7 +52,7 @@ For collateral, the protocol will accept wrapped Bitcoin and wrapped Ether, the 
 
 Alright, with things scoped out a bit, let's dive into writing some code. Start by creating the file `src/DecentralizedStableCoin.sol`. I'm hoping to make this as professional as possible, so I'm actually going to paste my contract and function layouts as a reference to the top of this file.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 // This is considered an Exogenous, Decentralized, Anchored (pegged), Crypto Collateralized low volatility coin
@@ -83,7 +83,7 @@ When I wrote this codebase, I intended to get it audited, and I did! You can act
 
 With that said, our contract boilerplate is going to be set up similarly to everything we've been doing so far. Let's add some NATSPEC to outline the contracts purpose.
 
-```js
+```solidity
 pragma solidity ^0.8.18;
 
 /*
@@ -117,7 +117,7 @@ remappings = ["@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts"]
 
 Rather than importing a standard ERC20 contract, we'll be leveraging the ERC20Burnable extension of this standard. ERC20Burnable includes `burn` functionality for our tokens which will be important when we need to take the asset out of circulation to support stability.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -151,7 +151,7 @@ In order to accomplish this, we're going to also inherit `Ownable` with Decentra
 > `constructor(address initialOwner) ERC20("DecentralizedStableCoin", "DSC")
 Ownable(initialOwner) {}`
 
-```js
+```solidity
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 ...
@@ -167,7 +167,7 @@ The two major functions we're going to want the DSCEngine to control are of cour
 
 We can start by writing our burn function.
 
-```js
+```solidity
 function burn(uint256 _amount) external override onlyOwner{}
 ```
 
@@ -178,7 +178,7 @@ We're going to want to check for two things when this function is called.
 
 We'll configure two custom errors for when these checks fail.
 
-```js
+```solidity
 contract DecentralizedStableCoin is ERC20Burnable, Ownable {
     error DecentralizedStableCoin__MustBeMoreThanZero();
     error DecentralizedStableCoin__BurnAmountExceedsBalance();
@@ -199,7 +199,7 @@ contract DecentralizedStableCoin is ERC20Burnable, Ownable {
 
 The last thing we're going to do, assuming these checks pass, is burn the passed amount of tokens. We're going to do this by using the `super` keyword. This tells solidity to use the burn function of the parent class.
 
-```js
+```solidity
 function burn(uint256 _amount) external override onlyOwner{
     uint256 balance = balanceOf(msg.sender);
     if(_amount <= 0){
@@ -216,7 +216,7 @@ function burn(uint256 _amount) external override onlyOwner{
 
 The second function we'll need to override to configure access control on is going to be our mint function.
 
-```js
+```solidity
 function mint(address _to, uint256 _amount) external overrides onlyOwner returns(bool){
 }
 ```
@@ -225,7 +225,7 @@ So, in this function we want to configure a boolean return value which is going 
 
 We'll of course want to revert with custom errors if these conditional checks fail.
 
-```js
+```solidity
 contract DecentralizedStableCoin is ERC20Burnable, Ownable {
     error DecentralizedStableCoin__MustBeMoreThanZero();
     error DecentralizedStableCoin__BurnAmountExceedsBalance();

--- a/courses/advanced-foundry/3-develop-defi-protocol/5-defi-dscengine-setup/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/5-defi-dscengine-setup/+page.md
@@ -14,7 +14,7 @@ We're going to build this a little differently than usual, as we'll likely be wr
 
 Begin with creating a new file, `src/DSCEngine.sol`. I'll bring over my contract and function layout reference and we can se up our boilerplate.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 // This is considered an Exogenous, Decentralized, Anchored (pegged), Crypto Collateralized low volatility coin
@@ -47,7 +47,7 @@ contract DSCEngine {}
 
 Time for NATSPEC, remember, we want to be as verbose and clear in presenting what our code is meant to do.
 
-```js
+```solidity
 /*
  * @title DSCEngine
  * @author Patrick Collins
@@ -101,7 +101,7 @@ Users will deposit collateral greater in value than the `DSC` they mint. If thei
 
 In addition to what's outlined above, we'll need some basic functions like `mint/deposit` etc to give users more granular control over their position and account `healthFactor`.
 
-```js
+```solidity
 contract DSCEngine {
 
 ///////////////////

--- a/courses/advanced-foundry/3-develop-defi-protocol/6-defi-deposit-collateral/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/6-defi-deposit-collateral/+page.md
@@ -15,7 +15,7 @@ To deposit collateral, users are going to need the address for the type of colla
 > ❗ **NOTE**
 > Don't forget the NATSPEC!
 
-```js
+```solidity
 ///////////////////
 //   Functions   //
 ///////////////////
@@ -39,7 +39,7 @@ It's likely that many functions in a protocol will require this kind of sanitati
 
 Our function layout reference says modifiers should come before our functions, so let's adhere to that. We'll need a new error is well.
 
-```js
+```solidity
 
 contract DSCEngine {
 
@@ -66,7 +66,7 @@ contract DSCEngine {
 
 This looks great! This should assure that the amount of collateral passed to our depositCollateral function is greater than zero. The other parameter of this function is the tokenCollateralAddress. Since we're only meaning to support wETH and wBTC, we should make a second modifier to assure only these allowed tokens are deposited as collateral.
 
-```js
+```solidity
 modifier isAllowedToken(address token){
 
 }
@@ -76,7 +76,7 @@ Currently, we don't have any reference to use in our conditional for this modifi
 
 We know we're going to be using chainlink pricefeeds, so what we can do is have this mapping be a token address, to it's associated pricefeed. In our modifier, if a pricefeed isn't found for the passed token address, it'll revert!
 
-```js
+```solidity
 /////////////////////////
 //   State Variables   //
 /////////////////////////
@@ -86,7 +86,7 @@ mapping(address token => address priceFeed) private s_priceFeeds;
 
 We'll probably want to initialize this mapping in our contract's constructor. To do this, we'll have our constructor take a list of token addresses and a list of priceFeed addresses, each index of one list will be mapped to the respective index of the other on deployment. We also know that the DSCEngine is going to need to know about the DecentralizeStablecoin contract. With all this in mind, let's set up our constructor.
 
-```js
+```solidity
 ///////////////////
 //   Functions   //
 ///////////////////
@@ -95,7 +95,7 @@ constructor(address[] memory tokenAddresses, address[] memory priceFeedAddresses
 
 Here's where we should definitely perform a sanity check, since a contract is only constructed once. If the indexes of our lists are meant to be mapped to each other, we should assure the lengths of the lists match, and if they don't we can revert with another custom error.
 
-```js
+```solidity
 ///////////////////
 //     Errors    //
 ///////////////////
@@ -117,7 +117,7 @@ constructor(address[] memory tokenAddresses, address[] memory priceFeedAddresses
 
 Now we can add our for loop which will map our two lists of addresses to each other.
 
-```js
+```solidity
 ///////////////////
 //   Functions   //
 ///////////////////
@@ -137,7 +137,7 @@ We're going to be doing lots with our `dscEngine`. We should declare this as an 
 > ❗ **NOTE**
 > Don't forget to import `DecentralizedStableCoin.sol`!
 
-```js
+```solidity
 import {DecentralizedStableCoin} from "DecentralizedStableCoin.sol";
 
 ...
@@ -168,7 +168,7 @@ constructor(address[] memory tokenAddresses, address[] memory priceFeedAddresses
 
 Remember, we were doing all this because we need a new modifier that checks our token addresses! Now that things are established in our constructor, we can write this modifier.
 
-```js
+```solidity
 
 contract DSCEngine {
 
@@ -204,7 +204,7 @@ contract DSCEngine {
 
 Great! Now, coming all the way back to our functions (told you we'd be moving fast!), we can add these newly created modifiers to `depositCollateral`.
 
-```js
+```solidity
 ///////////////////////////
 //   External Functions  //
 ///////////////////////////
@@ -225,7 +225,7 @@ Let's add the import to our contract.
 > in a different location. Edit the filepath from `/security/` to `/utils/` will
 > work.
 
-```js
+```solidity
 pragma solidity ^0.8.18;
 
 import {DecentralizedStableCoin} from "DecentralizedStableCoin.sol";
@@ -240,7 +240,7 @@ contract DSCEngine is ReentrancyGuard {
 
 Whew, all this and we haven't even started the function body yet! Let's start working with the deposited collateral. We'll need a way to keep track of the collateral deposited by each user. This sounds like a mapping to me.
 
-```js
+```solidity
 /////////////////////////
 //   State Variables   //
 /////////////////////////
@@ -252,7 +252,7 @@ mapping(address user => mapping(address token => uint256 amount)) private s_coll
 
 Now we can finally add the deposited collateral to our user's balance within our depositCollateral function.
 
-```js
+```solidity
 ///////////////////////////
 //   External Functions  //
 ///////////////////////////
@@ -268,7 +268,7 @@ function depositCollateral(address tokenCollateralAddress, uint256 amountCollate
 
 When we're changing the balance of our user's deposited collateral, what are we doing? We're updating our contract state! Any time state is changed, we should absolutely emit an event. Our contract layout tells us that events should be declared beneath our state variables. So, let's go ahead and declare this event and emit it in our depositCollateral function.
 
-```js
+```solidity
 ////////////////
 //   Events   //
 ////////////////
@@ -295,7 +295,7 @@ Our function so far is doing a great job adhering to CEI (Checks, Effects, Inter
 
 Let's add our interactions to the function now, we'll need to call transferFrom on wBTC or wETH. These are ERC20s remember, so let's import an interface to use.
 
-```js
+```solidity
 pragma solidity ^0.8.18;
 
 import {DecentralizedStableCoin} from "DecentralizedStableCoin.sol";
@@ -322,7 +322,7 @@ function depositCollateral(address tokenCollateralAddress, uint256 amountCollate
 
 One last thing to note in this function - our transferFrom call actually returns a boolean. We want to assure this transfer is successful, otherwise revert this function call. One last conditional to add...
 
-```js
+```solidity
 bool success = IERC20(tokenCollateralAddress).transferFrom(msg.sender, address(this), amountCollateral);
 
 if(!success){
@@ -332,7 +332,7 @@ if(!success){
 
 ...and one last custom error:
 
-```js
+```solidity
 
 contract DSCEngine {
 
@@ -362,7 +362,7 @@ See you in the next lesson!
 
 DSCEngine.sol
 
-```js
+```solidity
 // Layout of Contract:
 // version
 // imports

--- a/courses/advanced-foundry/3-develop-defi-protocol/8-defi-health-factor/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/8-defi-health-factor/+page.md
@@ -14,7 +14,7 @@ So far, our `_healthFactor` function is only acquiring the user's `totalDscMinte
 
 An account's `Health Factor` will be a bit more complex to consider than simply `collateralValueInUsd / totalDscMinted`. Remember, we want to assure the protocol is always `over-collateralized`, and to do this, there needs to be a threshold determined that this ratio needs to adhere to, 200% for example. We can set this threshold via a constant state variable.
 
-```js
+```solidity
 /////////////////////////
 //   State Variables   //
 /////////////////////////
@@ -33,7 +33,7 @@ uint256 private constant LIQUIDATION_PRECISION = 100;
 
 The threshold above, set at `50`, will assure a user's position is `200%` `over-collateralized`. We've also declared a `LIQUIDATION_PRECISION` constant for use in our calculation. We can apply this to our function's calculation now.
 
-```js
+```solidity
 /*
 * Returns how close to liquidation a user is
 * If a user goes below 1, then they can be liquidated.
@@ -65,7 +65,7 @@ In the above example, a user who has deposited $150 worth of ETH would not be ab
 
 With a `LIQUIDATION_THRESHOLD` of 50, a user requires 200% over-collateralization of their position, or the risk liquidation. Now that we've adjusted our collateral amount to account for a position's `LIQUIDATION_THRESHOLD`, we can use this adjust value to calculate a user's true `Health Factor`.
 
-```js
+```solidity
 /*
 * Returns how close to liquidation a user is
 * If a user goes below 1, then they can be liquidated.
@@ -89,7 +89,7 @@ return (0.75)
 
 Alright! Now, we've been talking about `Health Factors` which are `< 1` as being at risk of liquidation. We should set this constant officially with a state variable before moving on. We'll need it in our `_revertIfHealthFactorIsBroken` function.
 
-```js
+```solidity
 /////////////////////////
 //   State Variables   //
 /////////////////////////
@@ -109,7 +109,7 @@ uint256 private constant MIN_HEALTH_FACTOR = 1e18;
 
 We're ready to put our `_healthFactor` function and our `MIN_HEALTH_FACTOR` constant to work. We can use these to declare a conditional statement within `_revertIfHealthFactorIsBroken`, which will revert with a custom error if the conditional fails to pass.
 
-```js
+```solidity
 function _revertIfHealthFactorIsBroken(address user) internal view {
     uint256 userHealthFactor = _healthFactor(user);
     if(userHealthFactor < MIN_HEALTH_FACTOR){
@@ -120,7 +120,7 @@ function _revertIfHealthFactorIsBroken(address user) internal view {
 
 Don't forget to add the custom error to the top of our contract with the others.
 
-```js
+```solidity
 ///////////////////
 //     Errors    //
 ///////////////////
@@ -141,7 +141,7 @@ In the next lesson, we finish the `mintDsc` function! See you there!
 <details>
 <summary>DSCEngine.sol</summary>
 
-```js
+```solidity
 // Layout of Contract:
 // version
 // imports

--- a/courses/advanced-foundry/3-develop-defi-protocol/9-defi-finishing-mint-dsc/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/9-defi-finishing-mint-dsc/+page.md
@@ -10,7 +10,7 @@ _Follow along the course with this video._
 
 Ok, where were we!? We went down several rabbit holes all in effort of determining if a user should be able to call `mintDsc`. Let's get back to that function now and finish it off.
 
-```js
+```solidity
 function mintDsc(uint256 amountDscToMint) external moreThanZero(amountDscToMint) nonReentrant {
     s_DSCMinted[msg.sender] += amountDscToMint;
     _revertIfHealthFactorIsBroken(msg.sender);
@@ -19,7 +19,7 @@ function mintDsc(uint256 amountDscToMint) external moreThanZero(amountDscToMint)
 
 To this point, our function is adding the amount requested to mint to the user's balance. We're then checking if this new balance is breaking the user's `Health Factor`, and if so, we're reverting. If this function _doesn't_ revert - it's time to mint!
 
-```js
+```solidity
 function mintDsc(uint256 amountDscToMint) external moreThanZero(amountDscToMint) nonReentrant {
     s_DSCMinted[msg.sender] += amountDscToMint;
     _revertIfHealthFactorIsBroken(msg.sender);
@@ -29,7 +29,7 @@ function mintDsc(uint256 amountDscToMint) external moreThanZero(amountDscToMint)
 
 Our `mint` function returns a bool and takes `_to` and `_amount` parameters. We can use this bool to revert if minting our DSC fails for some reason.
 
-```js
+```solidity
 function mintDsc(uint256 amountDscToMint) external moreThanZero(amountDscToMint) nonReentrant {
     s_DSCMinted[msg.sender] += amountDscToMint;
     _revertIfHealthFactorIsBroken(msg.sender);
@@ -43,7 +43,7 @@ function mintDsc(uint256 amountDscToMint) external moreThanZero(amountDscToMint)
 
 Lastly, add our new custom error to the appropriate section at the top of the contract:
 
-```js
+```solidity
 ///////////////////
 //     Errors    //
 ///////////////////
@@ -67,7 +67,7 @@ See you soon!
 <details>
 <summary>DSCEngine.sol</summary>
 
-```js
+```solidity
 // Layout of Contract:
 // version
 // imports

--- a/courses/advanced-foundry/5-merkle-airdrop/10-signature-standards/+page.md
+++ b/courses/advanced-foundry/5-merkle-airdrop/10-signature-standards/+page.md
@@ -14,7 +14,7 @@ In this lesson, we will delve into Ethereum signature standards, specifically EI
 
 Let's start with a basic signature verification contract. It retrieves the **signer address** using the `ecrecover` function and then verifies signatures by comparing the signer with the expected one.
 
-```js
+```solidity
 function getSignerSimple(uint256 message, uint8 _v, bytes32 _r, bytes32 _s) public pure returns (address) {
     bytes32 hashedMessage = bytes32(message); // If string, use keccak256(abi.encodePacked(string))
     address signer = ecrecover(hashedMessage, _v, _r, _s);
@@ -24,7 +24,7 @@ function getSignerSimple(uint256 message, uint8 _v, bytes32 _r, bytes32 _s) publ
 
 > 🗒️ **NOTE**:br > `ecrecover` is a function built into the Ethereum protocol.
 
-```js
+```solidity
 function verifySignerSimple(
     uint256 message,
     uint8 _v,
@@ -60,7 +60,7 @@ This EIP standardizes the signed data format:
 
 Here is how to set up EIP 191, by encoding and then hashing the message before retrieving the signer:
 
-```js
+```solidity
 function getSigner191(uint256 message, uint8 _v, bytes32 _r, bytes32 _s) public view returns (address) {
     // Prepare data for hashing
     bytes1 prefix = bytes1(0x19);
@@ -91,7 +91,7 @@ EIP-712 is a standard for structuring and signing typed data in Ethereum, enhanc
 
 To define the domain separator, we first declare a domain separator struct and its type hash:
 
-```js
+```solidity
 struct EIP712Domain {
     string name;
     string version;
@@ -104,7 +104,7 @@ bytes32 constant EIP712DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,str
 
 The domain separator is obtained by encoding and hashing the `EIP712Domain` struct:
 
-```js
+```solidity
 bytes32 domainSeparator = keccak256(
   abi.encode(
     EIP712DOMAIN_TYPEHASH,
@@ -120,7 +120,7 @@ bytes32 domainSeparator = keccak256(
 
 First, define the message struct and its type hash:
 
-```js
+```solidity
 struct Message {
     uint256 number;
 };
@@ -130,7 +130,7 @@ bytes32 public constant MESSAGE_TYPEHASH = keccak256("Message(uint256 number)");
 
 Then encode and hash them together:
 
-```js
+```solidity
 bytes32 hashedMessage = keccak256(abi.encode(MESSAGE_TYPEHASH, Message({ number: message })));
 ```
 
@@ -144,7 +144,7 @@ Steps for EIP 712 implementation:
 4. Combine all elements with a prefix and version byte to form a final digest.
 5. Use `ecrecover` with the digest and signature to retrieve the signer's address and verify authenticity.
 
-```js
+```solidity
 contract SignatureVerifier {
 
     function getSignerEIP712(uint256 message, uint8 _v, bytes32 _r, bytes32 _s) public view returns (address) {
@@ -165,7 +165,7 @@ contract SignatureVerifier {
 
 We can then verify the signer as in the first example, but using `verifySignerEIP712`:
 
-```js
+```solidity
 function verifySignerEIP712(
     uint256 message,
     uint8 _v,
@@ -185,7 +185,7 @@ It's recommended to use OpenZeppelin libraries to simplify the process, by using
 
 - Create the message type hash and hash it with the message data:
 
-  ```js
+  ```solidity
   bytes32 public constant MESSAGE_TYPEHASH = keccak256("Message(uint256 message)");
 
   function getMessageHash(uint256 _message) public view returns (bytes32) {
@@ -202,14 +202,14 @@ It's recommended to use OpenZeppelin libraries to simplify the process, by using
 
 - Retrieve the signer with `ECDSA.tryRecover` and compare it to the actual signer:
 
-```js
+```solidity
 function getSignerOZ(uint256 digest, uint8 _v, bytes32 _r, bytes32 _s) public pure returns (address) {
     (address signer, /* ECDSA.RecoverError recoverError */, /* bytes32 signatureLength */ ) = ECDSA.tryRecover(digest, _v, _r, _s);
     return signer;
 }
 ```
 
-```js
+```solidity
 function verifySignerOZ(
     uint256 message,
     uint8 _v,

--- a/courses/advanced-foundry/5-merkle-airdrop/16-implementing-signatures/+page.md
+++ b/courses/advanced-foundry/5-merkle-airdrop/16-implementing-signatures/+page.md
@@ -14,7 +14,7 @@ In this lesson, we will implement signature verification in our [`MerkleAirdrop:
 
 Before verifying the signature, we need to check if the claim has already been made to avoid redundant verification. If the claim is new, we proceed to validate the signature by calling the internal `_isValidSignature` function. If the signature is invalid, the function will revert with a custom error `MerkleAirdrop__InvalidSignature()`.
 
-```js
+```solidity
 function claim(
     address account,
     uint256 amount,
@@ -41,7 +41,7 @@ To verify the signature, we'll implement `_isValidSignature`. This function requ
 
 The **message digest** is created using the `getMessage` function, which takes the account and the claimed amount as parameters and returns a specific hash type from OpenZeppelin's EIP 712 contract.
 
-```js
+```solidity
 function getMessage(address account, uint256 amount) public view returns (bytes32) {
     return _hashTypedDataV4(keccak256(abi.encode(
         MESSAGE_TYPEHASH,
@@ -53,7 +53,7 @@ function getMessage(address account, uint256 amount) public view returns (bytes3
 
 To use this function correctly, our contract must inherit from the EIP712 contract by adding the `is` keyword to the contract declaration and updating the constructor:
 
-```js
+```solidity
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
 contract MerkleAirdrop is EIP712 {
@@ -65,7 +65,7 @@ contract MerkleAirdrop is EIP712 {
 
 Next, define a struct for the message type and use it in the `MESSAGE_TYPEHASH` variable declaration and the `getMessage` function:
 
-```js
+```solidity
 struct AirdropClaim {
     address account;
     uint256 amount;
@@ -87,7 +87,7 @@ With this setup, we can correctly encode and hash the `MESSAGE_TYPEHASH`, accoun
 
 Finally, implement the `_isValidSignature` function:
 
-```js
+```solidity
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 function _isValidSignature(

--- a/courses/advanced-foundry/5-merkle-airdrop/17-modifying-the-tests/+page.md
+++ b/courses/advanced-foundry/5-merkle-airdrop/17-modifying-the-tests/+page.md
@@ -14,13 +14,13 @@ In this lesson, we'll explore how to empower a third party address, the `gasPaye
 
 First, in the `setup()` function, we'll create a new address, `gasPayer`, which will have permission to call the claim function:
 
-```js
+```solidity
 gasPayer = makeAddr("gasPayer");
 ```
 
 Next, the `user` address will sign a message with their private key, authorizing the `gasPayer` address to perform the claim:
 
-```js
+```solidity
 vm.startPrank(user);
 (uint8 v, bytes32 r, bytes32 s) = signMessage(userPrivKey, user);
 vm.stopPrank();
@@ -30,7 +30,7 @@ vm.stopPrank();
 
 The `signMessage` function will calculate the **message digest**, which will be signed using the user's private key. The `vm.sign` cheatcode will generate the v, r, and s values necessary for the signature:
 
-```js
+```solidity
 function signMessage(uint256 privKey, address account) public view returns (uint8 v, bytes32 r, bytes32 s) {
         bytes32 hashedMessage = airdrop.getMessageHash(account, AMOUNT_TO_CLAIM);
     (v, r, s) = vm.sign(privKey, hashedMessage);
@@ -41,7 +41,7 @@ function signMessage(uint256 privKey, address account) public view returns (uint
 
 Finally, the `gasPayer` address can call the `MerkleAirdrop::claim` function on behalf of the `user`, passing the user's signature (v, r, s) into the function:
 
-```js
+```solidity
 vm.prank(gasPayer);
 airdrop.claim(user, AMOUNT_TO_CLAIM, PROOF, v, r, s);
 ```

--- a/courses/advanced-foundry/5-merkle-airdrop/19-create-claiming-script/+page.md
+++ b/courses/advanced-foundry/5-merkle-airdrop/19-create-claiming-script/+page.md
@@ -14,7 +14,7 @@ In this lesson we are going to build a script to handle the **signing** and **cl
 
 We can begin by navigating into the `/script` folder and creating a `Interact.s.sol` file. To get the*most recently deployed airdrop contract*, we will use DevOps tools from Cyfrin foundry-devops, which should be already installed in this project.
 
-```js
+```solidity
 import { Script, console } from "forge-std/Script.sol";
 import { DevOpsTools } from "foundry-devops/src/DevOpsTools.sol";
 import { MerkleAirdrop } from "../src/MerkleAirdrop.sol";
@@ -28,7 +28,7 @@ contract ClaimAirdrop is Script {
 
 Within the `run` function, we'll retrieve the most recently deployed `MerkleAirdrop` contract address and pass this contract address to a function `claimAirdrop`:
 
-```js
+```solidity
 function run() external {
         address mostRecentlyDeployed = DevOpsTools.get_most_recent_deployment("MerkleAirdrop", block.chainid);
         claimAirdrop(mostRecentlyDeployed);
@@ -52,7 +52,7 @@ Next, we invoke the `MerkleAirdrop::claim` function, passing the following requi
 
 Here is the function:
 
-```js
+```solidity
 function claimAirdrop(address airdrop) public {
     vm.startBroadcast();
     // v, r, s are retrieved in the following lesson

--- a/courses/advanced-foundry/5-merkle-airdrop/2-project-setup/+page.md
+++ b/courses/advanced-foundry/5-merkle-airdrop/2-project-setup/+page.md
@@ -22,7 +22,7 @@ remappings = [ '@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/']
 
 And then we are ready to create the contract, which will contain a `constructor` and a `mint` function:
 
-```js
+```solidity
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -40,7 +40,7 @@ contract BagelToken is ERC20, Ownable {
 
 We can then create a new file named `MerkleAirdrop.sol`, where we will have a list of addresses and someone from that list who can claim ERC20 tokens.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
@@ -52,13 +52,13 @@ contract MerkleAirdrop {
 
 The contracts will be connected by passing the `BagelToken`, or any ERC20 token to the `MerkleAirdrop` constructor. Then we can add our claimer address into an array of addresses:
 
-```js
+```solidity
 address [] claimers;
 ```
 
 Then we would need a function that checks that the claimer is in this whitelist and allow him to receive tokens.
 
-```js
+```solidity
 function claim(address account) external {
     for (uint256 i=0; i<claimers.length; i++){
         //check if the account is in the claimers array

--- a/courses/advanced-foundry/5-merkle-airdrop/21-splitting-a-signature/+page.md
+++ b/courses/advanced-foundry/5-merkle-airdrop/21-splitting-a-signature/+page.md
@@ -8,7 +8,7 @@ _Follow along with the video_
 
 In this lesson we are going to split the signature into its _v,r,s_, component starting by saving this byte signature as a variable:
 
-```js
+```solidity
 bytes private SIGNATURE = hex"fbda..c11c";
 ```
 
@@ -20,7 +20,7 @@ In this `SIGNATURE` variable, the _r,s,v_ values are concatenated together in th
 
 To isolate each component, we'll create a function called `splitSignature` . This function will verify that the signature is 65 bytes long. If it is, we can proceed to split it into its components, otherwise we will revert with a custom error.
 
-```js
+```solidity
   function splitSignature(bytes memory sig) public pure returns (uint8 v, bytes32 r, bytes32 s) {
         if (sig.length != 65) {
             revert __ClaimAirdropScript__InvalidSignatureLength();

--- a/courses/advanced-foundry/5-merkle-airdrop/4-base-airdrop-contract/+page.md
+++ b/courses/advanced-foundry/5-merkle-airdrop/4-base-airdrop-contract/+page.md
@@ -14,7 +14,7 @@ In this lesson, we are going to implement Merkle proofs and Merkle trees in our 
 
 The constructor should take an ERC-20 token and a Merkle root as parameters, to store them for later use:
 
-```js
+```solidity
 constructor(bytes32 merkleRoot, IERC20 airdropToken) {
     i_merkleRoot = merkleRoot;
     i_airdropToken = airdropToken;
@@ -54,7 +54,7 @@ To allow users on the allowed list to claim tokens, we can create a `claim` func
 
 To verify the proof, we utilize OpenZeppelin's `MerkleProof::verify` function, which processes the proof, the merkle root and the encoded data. If the function will not succeed, we will revert with the `MerkleAirdrop__InvalidProof` custom error.
 
-```js
+```solidity
 function claim(address account, uint256 amount, bytes32[] calldata merkleProof) external {
     bytes32 leaf = keccak256(bytes.concat(keccak256(abi.encode(account, amount))));
     if (!MerkleProof.verify(merkleProof, i_merkleRoot, leaf)) {
@@ -67,13 +67,13 @@ function claim(address account, uint256 amount, bytes32[] calldata merkleProof) 
 
 After successful verification and prior to transferring tokens, it is recommended to emit an event:
 
-```js
+```solidity
 event Claim(address indexed account, uint256 indexed amount);
 ```
 
 We can then use `safeTransfer` from the `SafeERC20` library to handle token transfers securely:
 
-```js
+```solidity
 i_airdropToken.safeTransfer(account, amount);
 ```
 

--- a/courses/advanced-foundry/5-merkle-airdrop/7-writing-the-tests/+page.md
+++ b/courses/advanced-foundry/5-merkle-airdrop/7-writing-the-tests/+page.md
@@ -14,7 +14,7 @@ In this lesson, we are going to build a comprehensive test for the `MerkleAirdro
 
 We begin by deploying both the `BagelToken` and the `MerkleAirdrop` contracts in our `setup()` function. To properly set up the `MerkleAirdrop` contract, we need the hash `ROOT` variable, which can be retrieved from the output file that we generated in the previous lesson.
 
-```js
+```solidity
 bytes32 ROOT = 0xaa5d581231e596618465a56aa0f5870ba6e20785fe436d5bfb82b08662ccc7c4;
 
 function setUp() public {
@@ -25,7 +25,7 @@ function setUp() public {
 
 Additionally, we create a predictable address and private key by adding this line in our `setUp()` function:
 
-```js
+```solidity
 (user, userPrivKey) = makeAddrAndKey("user");
 ```
 
@@ -33,7 +33,7 @@ We log the user address and copy it to the array of addresses in the `GenerateIn
 
 To ensure the Merkle AirDrop contract can send tokens, it must hold enough of them. After deploying the contracts, we mint tokens to the owner and transfer the required amount to the AirDrop contract.
 
-```js
+```solidity
 token.mint(address(this), amountToSend);
 token.transfer(address(airdrop), amountToSend);
 ```
@@ -44,7 +44,7 @@ After this, we run the scripts again to generate the input and output files, upd
 
 In our test, we'll first store the user's initial balance, which is equal to zero. We then use the `vm.prank` cheat code to simulate the user calling the `claim` function on the `MerkleAirdrop` contract. The claim function requires the user address, the amount to claim, and the proof values as parameters, which can be copied from the output file we just generated. We then verify the ending balance of the user, ensuring it's equal to the claimed amount.
 
-```js
+```solidity
 bytes32 proofOne = 0x0fd7c981d39bece61f7499702bf59b3114a90e66b51ba2c53abdf7b62986c00a;
 bytes32 proofTwo = 0xe5ebd1e1b5a5478a944ecab36a9a954ac3b6b8216875f6524caa7a1d87096576;
 bytes32[] proof = [proofOne, proofTwo];

--- a/courses/advanced-foundry/5-merkle-airdrop/8-deployment-script/+page.md
+++ b/courses/advanced-foundry/5-merkle-airdrop/8-deployment-script/+page.md
@@ -12,7 +12,7 @@ To deploy the `BagelToken` and `MerkleAirdrop` contracts, we can follow a struct
 
 Inside the `script` directory, we can start coding the deployment contract by importing the required libraries:
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
@@ -24,7 +24,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 Next, create the deployment function to deploy the contracts, mint tokens, and transfer them to the airdrop contract:
 
-```js
+```solidity
 function deployMerkleAirdrop() public returns (MerkleAirdrop, BagelToken) {
     vm.startBroadcast();
     BagelToken bagelToken = new BagelToken();
@@ -46,7 +46,7 @@ forge install cyfrin/foundry-devops --no-commit
 
 Then, in the `setUp` function, add a check to determine if the current chain is ZKsync:
 
-```js
+```solidity
 //..
 import {ZkSyncChainChecker} from "foundry-devops/src/ZkSyncChainChecker.sol";
 

--- a/courses/advanced-foundry/6-upgradeable-smart-contracts/2-delegate-call/+page.md
+++ b/courses/advanced-foundry/6-upgradeable-smart-contracts/2-delegate-call/+page.md
@@ -18,7 +18,7 @@ Let's consider the two simple contracts provided as examples:
 
 Contract B is very simple, it contains 3 storage variables which are set by the setVars function.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
@@ -43,7 +43,7 @@ If we recall, storage acts _kind of_ like an array and each storage variable is 
 
 Now consider Contract A:
 
-```js
+```solidity
 contract A {
     uint256 public num;
     address public sender;

--- a/courses/advanced-foundry/6-upgradeable-smart-contracts/3-eip-1967/+page.md
+++ b/courses/advanced-foundry/6-upgradeable-smart-contracts/3-eip-1967/+page.md
@@ -16,7 +16,7 @@ In this lesson we'll apply what we've learnt and get our hands dirty with a smal
 <details>
 <summary>SmallProxy.sol</summary>
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.19;
@@ -51,7 +51,7 @@ Now, within `SmallProxy` we're importing Proxy.sol from our good friends OpenZep
 <details>
 <summary>Proxy.sol</summary>
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (proxy/Proxy.sol)
 
@@ -139,14 +139,14 @@ The need to regularly utilize storage to reference things in implementation (spe
 
 In our minimalistic example, we're assigning our \_IMPLEMENTATION_SLOT to a constant value for this purpose.
 
-```js
+```solidity
 // This is the keccak-256 hash of "eip1967.proxy.implementation" subtracted by 1
 bytes32 private constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 ```
 
 To illustrate this, let's write a basic implementation contracts, you can add this directly into SmallProxy.sol in Remix.
 
-```js
+```solidity
 contract ImplementationA{
     uint256 public value;
 
@@ -160,7 +160,7 @@ Great, so any time a call is sent to our proxy contract, we would expect it to b
 
 To make it a little easier to check the data stored in SmallProxy.sol we can add a couple helper functions.
 
-```js
+```solidity
 function getDataToTransact(uint256 numberToUpdate) public pure returns (bytes memory){
     return abi.encodeWithSignature("setValue(uint256)", numberToUpdate)
 }
@@ -168,7 +168,7 @@ function getDataToTransact(uint256 numberToUpdate) public pure returns (bytes me
 
 You should remember this abi encoding from the NFT section, where we learnt how to encode anything! This function will help us encode the call data we need to send to our proxy. In addition to this, let's set up a function to check the storage in our proxy, allowing us to see how it's changing.
 
-```js
+```solidity
 function readStorage() public view returns(uint256 valueAtStorageSlotZero){
     assembly{
         valueAtStorageSlotZero := sload(0)
@@ -195,7 +195,7 @@ To see this in action, we just need to paste our `getDataToTransact` return valu
 
 Now, let's demonstrate how upgrading this protocol would work. Add another contract to SmallProxy.sol:
 
-```js
+```solidity
 contract ImplementationB {
     uint256 public value;
 

--- a/courses/advanced-foundry/6-upgradeable-smart-contracts/4-uups/+page.md
+++ b/courses/advanced-foundry/6-upgradeable-smart-contracts/4-uups/+page.md
@@ -29,7 +29,7 @@ Go ahead and delete the placeholder/example contracts in our new Foundry project
 
 We'll begin with creating a minimalistic contract that we're going to upgrade. Create `src/BoxV1.sol` and start with our boilerplate.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -41,7 +41,7 @@ Again, because we're going to be employing UUPS, all of the upgradeability logic
 
 Our BoxV1 is going to be very simple, we'll have two functions, one which returns a number, and another which returns our protocol version.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -61,7 +61,7 @@ contract BoxV1 {
 
 Looks great, except...oh no! We didn't include a function to _set_ our number. Let's create a BoxV2.sol which addresses this and updated our version number.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -99,7 +99,7 @@ remappings = [
 
 And now, we can import UUPSUpgradeable into BoxV1.sol and break down how it's applied.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -139,7 +139,7 @@ Abstract contracts have some of their functions defined, and others undefined. T
 
 An example of an undefined function within UUPSUpgradeable would be \_authorizeUpgrade.
 
-````js
+````solidity
 /**
  * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract. Called by
  * {upgradeToAndCall}.
@@ -155,7 +155,7 @@ function _authorizeUpgrade(address newImplementation) internal virtual;
 
 This is a function we'll need to define within our protocol with the logic to denote how an upgrade is authorized, perhaps limitations on who can upgrade with a check on msg.sender, for example. Let's go ahead and implement this override function in BoxV1.sol now.
 
-```js
+```solidity
 function _authorizeUpgrade(address newImplementation) internal override {}
 ```
 
@@ -165,7 +165,7 @@ This line is actually all that's needed. For our example, we're not going to imp
 
 In older implementations of UUPSUpgradeable, you may see a line that I wanted to draw special attention to.
 
-```js
+```solidity
 /*
  * @dev This empty reserved space is put in place to allow future versions to add new variables without shifting down storage in the inheritance chain.
  * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
@@ -181,7 +181,7 @@ Storage gaps are an effort to get ahead of this problem by pre-allocating an arr
 
 ### Initializer
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -205,7 +205,7 @@ contract BoxV1 is UUPSUpgradeable {
 
 BoxV1 as written above is deployable and could be upgraded, BoxV2 can't be upgraded, but we'll cross that bridge later. If you look at the examples of OpenZeppelin UUPS contract on their Contract Wizard, you'll see that they are importing far more than we are however. One of which is the Initializable.sol library. Let's import this into BoxV1 and discuss it's importance here.
 
-```js
+```solidity
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 ```
 
@@ -219,7 +219,7 @@ Because storage for a proxied protocol is stored in the proxy, any initial set u
 
 This is such a concern that common practice is to include a constructor within an implementation contract which _explicitly_ disables initialization functions, assuring that this needs to be done through the proxy.
 
-```js
+```solidity
 
 constructor() {
     _disableInitializers();
@@ -228,13 +228,13 @@ constructor() {
 
 If we add this to our BoxV1, we'll then need to add initialization logic to it as well.
 
-```js
+```solidity
 function initialize() public initializer {}
 ```
 
 It's within this initialize function that we would include the logic that we would normally have within a constructor. If we wanted our BoxV1 protocol to be ownable, for example, we would import OwnableUpgradeable and Initializable and then define the above functions like so:
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -277,7 +277,7 @@ Common convention is to prepend initializer functions with a double-underscore `
 
 We can give BoxV2 the same treatment.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;

--- a/courses/advanced-foundry/6-upgradeable-smart-contracts/5-uups-deploy/+page.md
+++ b/courses/advanced-foundry/6-upgradeable-smart-contracts/5-uups-deploy/+page.md
@@ -24,7 +24,7 @@ Our deployment script should be very familiar to us by now!
 > ❗ **PROTIP**
 > Repetition is the mother of skill.
 
-```js
+```solidity
 //SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -54,13 +54,13 @@ In order to access OpenZeppelin's ERC1967 implementation, we'll need to install 
 forge install OpenZeppelin/openzeppelin-contracts --no-commit
 ```
 
-```js
+```solidity
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 ```
 
 We'll also need to add this remapping to our `foundry.toml`.
 
-```js
+```solidity
 remappings = [
   "@openzeppelin/contracts=lib/openzeppelin-contracts/contracts",
   "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts",
@@ -69,7 +69,7 @@ remappings = [
 
 Finally, we can add the deployment of our proxy to our deploy script. The ERC1967Proxy contract _does_ have a constructor we need to consider.
 
-```js
+```solidity
 constructor(address implementation, bytes memory _data) payable {
     ERC1967Utils.upgradeToAndCall(implementation, _data);
 }
@@ -77,7 +77,7 @@ constructor(address implementation, bytes memory _data) payable {
 
 This constructor is expecting two arguments to be passed, the first is our implementation contract, as to be expected. The second is `_data`. This data parameter can be used to pass function call data to be executed after deployment ie - calling an initializer function. We won't be employing this functionality, so our data parameter is going to be empty.
 
-```js
+```solidity
 //SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;

--- a/courses/advanced-foundry/6-upgradeable-smart-contracts/6-uups-upgrade/+page.md
+++ b/courses/advanced-foundry/6-upgradeable-smart-contracts/6-uups-upgrade/+page.md
@@ -10,7 +10,7 @@ _Follow along the course with this video._
 
 Let's keep our momentum from the last lesson and jump right into writing our UpgradeBox.s.sol script. The boilerplate for this will be as expected.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -30,7 +30,7 @@ forge install Cyfrin/foundry-devops --no-commit
 
 We can then import this and leverage the get_most_recent_deployment functionality to acquire our ERC1967Proxy address.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -47,7 +47,7 @@ contract UpgradeBox is Script {
 
 Next, we'll need to import and deploy BoxV2!
 
-```js
+```solidity
 ...
 import {BoxV2} from "../src/BoxV2.sol";
 
@@ -64,7 +64,7 @@ contract UpgradeBox is Script{
 
 In order to modularize things a bit for the tests we'll write in the next lesson, we'll write an `upgradeBox` function in which our proxy is called.
 
-```js
+```solidity
 function upgradeBox(address proxyAddress, address newBox) public returns (address) {
     vm.startBroadcast();
     BoxV1 proxy = BoxV1(proxyAddress);
@@ -80,7 +80,7 @@ function upgradeBox(address proxyAddress, address newBox) public returns (addres
 
 Now, we can add upgradeBox to our scripts run function.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;

--- a/courses/advanced-foundry/6-upgradeable-smart-contracts/7-uups-tests/+page.md
+++ b/courses/advanced-foundry/6-upgradeable-smart-contracts/7-uups-tests/+page.md
@@ -12,7 +12,7 @@ In this lesson we're going to be writing our test suite which will enable us to 
 
 Begin by creating the file `test/DeployAndUpgradeTest.t.sol`. We know the drill in setting this up by now!
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -42,7 +42,7 @@ This is a little more than boilerplate, but I trust your skills to be improving 
 
 Now we can write our test, we'll need to deploy BoxV2.
 
-```js
+```solidity
 function testUpgrades() public {
     BoxV2 box2 = new BoxV2();
 
@@ -52,7 +52,7 @@ function testUpgrades() public {
 
 Recall what our upgradeBox function is going within UpgradeBox.s.sol:
 
-```js
+```solidity
 function upgradeBox(address proxyAddress, address newBox) public returns (address) {
     vm.startBroadcast();
     BoxV1 proxy = BoxV1(proxyAddress);
@@ -67,7 +67,7 @@ This function is taking the proxy address and our new implementation address as 
 
 Now, in our test, we can set an expected value and compare it against what version a call to the `version` function on our proxy will return.
 
-```js
+```solidity
 function testUpgrades() public {
     BoxV2 box2 = new BoxV2();
 
@@ -80,7 +80,7 @@ function testUpgrades() public {
 
 It's best practice to split tests up as best one can, but let's check more here while we're at it. We added new function to BoxV2, let's ensure they work after our upgrade.
 
-```js
+```solidity
 function testUpgrades() public {
     BoxV2 box2 = new BoxV2();
 
@@ -96,7 +96,7 @@ function testUpgrades() public {
 
 You know what, I changed my mind, let's add one more simple test to verify the implementation we begin with.
 
-```js
+```solidity
 function testProxyStartAsBoxV1() public {
     vm.expectRevert();
     BoxV2(proxy).setNumber(7);

--- a/courses/advanced-foundry/7-account-abstraction/10-unsigned-packed-user-op-test/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/10-unsigned-packed-user-op-test/+page.md
@@ -21,7 +21,7 @@ First, we are going to write a script that will help us generate the data for th
 
 **<span style="color:red">SendPackedUserOp.s.sol</span>**
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
@@ -41,7 +41,7 @@ contract SendPackedUserOp is Script {
 
 For step 1, we are going to create a separate function called `_generateUnsignedUserOperation`. It will take `bytes memory calldata`, `address sender`, and `uint256 nonce`. It will populate all the fields of the `PackedUserOperation` except for the signature. We will also need some variables for gas limits.
 
-```js
+```solidity
 function _generateUnsignedUserOperation(bytes memory callData)
     internal pure returns (PackedUserOperation memory) {
 
@@ -68,7 +68,7 @@ function _generateUnsignedUserOperation(bytes memory callData)
 
 Now we can use our `_generateUnsignedUserOperation` function for step 1 of our `generateSignedUserOperation` function.
 
-```js
+```solidity
 function generateSignedUserOperation(bytes memory callData, address sender)
     public view returns (PackedUserOperation memory) {
         // Step 1. Generate the unsigned data

--- a/courses/advanced-foundry/7-account-abstraction/12-local-dev-unlocked/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/12-local-dev-unlocked/+page.md
@@ -10,7 +10,7 @@ Picking up where we left off from lesson 11, we are going to have to do a work a
 
 **<span style="color:red">SendPackedUserOp.s.sol</span>**
 
-```js
+```solidity
 // 3. Sign it
 (uint8 v, bytes32 r, bytes32 s) = vm.sign(config.account, digest);
 userOp.signature = abi.encodePacked(r, s, v); // Note the order
@@ -29,7 +29,7 @@ Here's what we need to do in our refactored code.
 
 This is what our refactored code should look like.
 
-```js
+```solidity
 // 3. Sign it
 uint8 v;
 bytes32 r;
@@ -54,7 +54,7 @@ Since we are using a local chain, we need to do some refactoring over in HelperC
 
 **<span style="color:red">HelperConfig.s.sol</span>**
 
-```js
+```solidity
 address constant ANVIL_DEFAULT_ACCOUNT = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 
 
@@ -87,7 +87,7 @@ We need to do a bit more work in `getOrCreateAnvilEthConfig`. At the bottom of t
 - set `localNetworkConfig` to `NetworkConfig`
 - return `localNetworkConfig`
 
-```js
+```solidity
 localNetworkConfig = NetworkConfig({
   entryPoint: address(entryPoint),
   usdc: address(erc20Mock),
@@ -105,7 +105,7 @@ Now that we have Anvil set, we need to make a minor change over in our `DeployMi
 
 **<span style="color:red">DeployMinimal.s.sol</span>**
 
-```js
+```solidity
 vm.startBroadcast(config.account);
 MinimalAccount minimalAccount = new MinimalAccount(config.entryPoint);
 minimalAccount.transferOwnership(config.account);

--- a/courses/advanced-foundry/7-account-abstraction/13-test-validate-user-ops/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/13-test-validate-user-ops/+page.md
@@ -14,7 +14,7 @@ Let's get started!
 In our test function, we can simply copy and paste the Arrange from `testRecoverSignedOp`. 
 
 **<span style="color:red">MinimalAccountTest.t.sol</span>**
-```js
+```solidity
 function testValidationOfUserOps() public {
     // Arrange
     assertEq(usdc.balanceOf(address(minimalAccount)), 0);
@@ -35,7 +35,7 @@ In our **Act**, we want to make sure that `validateUserOp` returns correctly. If
 
 You will also notice that it takes a  `userOp`, `userOpHash`, and `missingAccountFunds`. We'll need to set this to our `validationData`. We already have `packedUserOp` and `userOperationHash` in our **Arrange**. We will need to add `missingAccountFunds` there as well. Let's make it a `uint256` and set it to 1e18 **(to simulate the amount of funds that are missing from the account)**. Lastly, we remember that our `SIG_VALIDATION_SUCCESS` = 0. So, we'll assume this will be the case in this test. 
 
-```js
+```solidity
 uint256 missingAccountFunds = 1e18;
 
 // Act
@@ -46,7 +46,7 @@ assertEq(validationData, 0);
 
 With that, our function should now look like this.
 
-```js
+```solidity
 function testValidationOfUserOps() public {
     // Arrange
     assertEq(usdc.balanceOf(address(minimalAccount)), 0);

--- a/courses/advanced-foundry/7-account-abstraction/14-test-entrypoint/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/14-test-entrypoint/+page.md
@@ -17,7 +17,7 @@ Let's start by setting up our `testEntryPointCanExecuteCommands` function with *
 
 **<span style="color:red">MinimalAccountTest.t.sol</span>**
 
-```js
+```solidity
 function testEntryPointCanExecuteCommands() public {
     // Arrange
 
@@ -31,7 +31,7 @@ function testEntryPointCanExecuteCommands() public {
 
 For starters, we can simply grab all of **Assert** from `testValidationOfUserOps`, except for the last line - `uint256 missingAccountFunds = 1e18;`.
 
-```js
+```solidity
 // Arrange
 assertEq(usdc.balanceOf(address(minimalAccount)), 0);
 address dest = address(usdc);
@@ -48,7 +48,7 @@ bytes32 userOperationHash = IEntryPoint(helperConfig.getConfig().entryPoint).get
 
 In the previous lesson, we added `missingAccountfunds` to simulate the amount of funds that are missing from the account. We know that the alt-mempool initially covers these costs. Now we need to pay them back. To do this, we will use `vm.deal(address(minimalAccount), 1e18);`.
 
-```js
+```solidity
 // Arrange
 assertEq(usdc.balanceOf(address(minimalAccount)), 0);
 address dest = address(usdc);
@@ -68,7 +68,7 @@ vm.deal(address(minimalAccount), 1e18);
 
 In our **Act**, we will use vm.prank to be a random user. This means that anyone can send our transaction as long as we sign it.
 
-```js
+```solidity
 // Act
 vm.prank(randomuser);
 ```
@@ -79,7 +79,7 @@ Additionally, if you go into `handleOps` or the `EntryPoint` you'll see that it 
 
 **<span style="color:red">EntryPoint.sol</span>**
 
-```js
+```solidity
 /// @inheritdoc IEntryPoint
 function handleOps(
     PackedUserOperation[] calldata ops,
@@ -93,7 +93,7 @@ In our case, the beneficiary will be the `randomuser`. This means that we will b
 
 **<span style="color:red">MinimalAccountTest.t.sol</span>**
 
-```js
+```solidity
 PackedUserOperation[] memory ops = new PackedUserOperation[](1);
 ops[0] = packedUserOp;
 
@@ -108,7 +108,7 @@ IEntryPoint(helperConfig.getConfig().entryPoint).handleOps(ops, payable(randomus
 
 Now we can move on to our Assert, which is exactly the same as in `testOwnerCanExecuteCommands`. Just copy and paste it.
 
-```js
+```solidity
 assertEq(usdc.balanceOf(address(minimalAccount)), AMOUNT);
 ```
 
@@ -116,7 +116,7 @@ assertEq(usdc.balanceOf(address(minimalAccount)), AMOUNT);
 
 **Our completed code should look like this: **
 
-```js
+```solidity
 function testEntryPointCanExecuteCommands() public {
     // Arrange
     assertEq(usdc.balanceOf(address(minimalAccount)), 0);

--- a/courses/advanced-foundry/7-account-abstraction/15-advanced-debugging/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/15-advanced-debugging/+page.md
@@ -45,7 +45,7 @@ Let's inspect this line a bit further.
 
 ---
 
-```js
+```solidity
 try IAccount(sender).validateUserOp{gas: verificationGasLimit}(op, opInfo.userOpHash, missingAccountFunds)
 ```
 
@@ -65,7 +65,7 @@ Our updated part of our function will look like this:
 
 ---
 
-```js
+```solidity
 function generateSignedUserOperation(
         bytes memory callData,
         HelperConfig.NetworkConfig memory config,
@@ -95,7 +95,7 @@ Look in **Arrange** of the above test and make your change in `packedUserOp` You
 
 ---
 
-```js
+```solidity
 PackedUserOperation memory packedUserOp = sendPackedUserOp.generateSignedUserOperation(
     executeCallData, helperConfig.getConfig(), address(minimalAccount));
 ```
@@ -114,7 +114,7 @@ This will give us the last successful transaction, rather than the next one in t
 
 ---
 
-```js
+```solidity
 function generateSignedUserOperation(
         bytes memory callData,
         HelperConfig.NetworkConfig memory config,

--- a/courses/advanced-foundry/7-account-abstraction/17-live-demo-eth/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/17-live-demo-eth/+page.md
@@ -24,7 +24,7 @@ We forgot to complete the `run` function in our `SendPackedUserOp` script. Let's
 
 **<span style="color:red">SendPackedUserOp.s.sol</span>**
 
-```js
+```solidity
 // Add these imports
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {MinimalAccount} from "src/ethereum/MinimalAccount.sol";

--- a/courses/advanced-foundry/7-account-abstraction/18-zksync-setup/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/18-zksync-setup/+page.md
@@ -68,7 +68,7 @@ Go into zksync folder in your src. Create a new file and call it `ZkMinimalAccou
 
 ---
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 

--- a/courses/advanced-foundry/7-account-abstraction/19-iaccount/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/19-iaccount/+page.md
@@ -8,7 +8,7 @@ Now that we've got our functions, let's take a look at them to understand what t
 
 ---
 
-```js
+```solidity
 function validateTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, Transaction memory _transaction)
     external
     payable
@@ -26,7 +26,7 @@ You may have noticed that it is similar to the validateUserOp function in our Mi
 
 **<summary><span style="color:red">MemoryTransactionHelper.sol</span></summary>**
 
-```js
+```solidity
 /// @notice Structure used to represent a ZKsync transaction.
 struct Transaction {
     // The type of the transaction.
@@ -89,7 +89,7 @@ For now, let's consider `returns (bytes4 magic)` as a bool. For example, if we w
 
 ---
 
-```js
+```solidity
 returns (bytes4 magic)
 {
     return IAccount.validateTransaction.selector;
@@ -100,7 +100,7 @@ returns (bytes4 magic)
 
 ### Execute Transaction
 
-```js
+```solidity
 function executeTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, Transaction memory _transaction)
     external
     payable
@@ -113,7 +113,7 @@ I know what you're thinking. "This is similar to the `execute` function from `Mi
 
 ---
 
-```js
+```solidity
 function executeTransactionFromOutside(Transaction memory _transaction) external payable
 {}
 ```
@@ -134,7 +134,7 @@ The `payForTransaction` is similar to `_payPreFund`. This is where we state who 
 
 ---
 
-```js
+```solidity
 function payForTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, Transaction memory _transaction)
         external
         payable

--- a/courses/advanced-foundry/7-account-abstraction/21-type-113-lifecycle/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/21-type-113-lifecycle/+page.md
@@ -43,7 +43,7 @@ In our `ZkMinimalAccount`, `validateTransaction` will be called. If successful, 
 
 ---
 
-```js
+```solidity
 function validateTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, Transaction memory _transaction)
     external
     payable
@@ -69,7 +69,7 @@ Essentially, if `validateTransaction` does not update the nonce, the entire tran
 
 Once the validation phase is successful, it is sent to the main node and `executeTransaction` can be called in our `ZkMinimalAccount`. If a paymaster was used, the `postTransaction` is called.
 
-```js
+```solidity
 function executeTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, Transaction memory _transaction)
     external
     payable

--- a/courses/advanced-foundry/7-account-abstraction/23-zksync-simulations/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/23-zksync-simulations/+page.md
@@ -39,7 +39,7 @@ Paste this above your `validateTransactions` function.
 
 ---
 
-```js
+```solidity
 /*//////////////////////////////////////////////////////////////
                            EXTERNAL FUNCTIONS
 //////////////////////////////////////////////////////////////*/
@@ -53,7 +53,7 @@ Paste this below your `prepareForPaymaster` function.
 
 ---
 
-```js
+```solidity
 /*//////////////////////////////////////////////////////////////
                            INTERNAL FUNCTIONS
 //////////////////////////////////////////////////////////////*/
@@ -65,7 +65,7 @@ Paste this below your `prepareForPaymaster` function.
 
 Let's get started with our `validateTransaction` function. Step 2 of the validation phase requires this function to update the nonce and validate the transaction. Additionally, we will use this function to check if we have enough money in our account.
 
-```js
+```solidity
 /*//////////////////////////////////////////////////////////////
                            EXTERNAL FUNCTIONS
 //////////////////////////////////////////////////////////////*/
@@ -92,7 +92,7 @@ In order for us to make this work, we'll have to make a systems contract call. I
 
 **<span style="color:red">NonceHolder.sol</span>**
 
-```js
+```solidity
 /// @notice A convenience method to increment the minimal nonce if it is equal
 /// to the `_expectedNonce`.
 /// @param _expectedNonce The expected minimal nonce for the account.
@@ -135,7 +135,7 @@ To make things a bit easier for us we are going to import the [SystemsContractCa
 
 ---
 
-```js
+```solidity
 import { SystemContractsCaller } from "lib/foundry-era-contracts/src/system-contracts/contracts/libraries/SystemContractsCaller.sol";
 ```
 
@@ -145,7 +145,7 @@ Around line 142 you will see the `systemCallWithPropagatedRevert` function. This
 
 **<span style="color:red">SystemContractsCaller.sol</span>**
 
-```js
+```solidity
 /// @notice Makes a call with the `isSystem` flag.
 /// @param gasLimit The gas limit for the call.
 /// @param to The address to call.
@@ -192,14 +192,14 @@ Now that we've got this, let's add it to our `validateTransaction` function back
 
 We'll need a couple of imports first.
 
-```js
+```solidity
 import { NONCE_HOLDER_SYSTEM_CONTRACT } from "lib/foundry-era-contracts/src/system-contracts/contracts/Constants.sol";
 import { INonceHolder } from "lib/foundry-era-contracts/src/system-contracts/contracts/interfaces/INonceHolder.sol";
 ```
 
 **Inside `validateTransaction` function**
 
-```js
+```solidity
 {
   // Call NonceHolder
   // increment nonce by 1

--- a/courses/advanced-foundry/7-account-abstraction/24-validate-tx/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/24-validate-tx/+page.md
@@ -14,7 +14,7 @@ Let's get started!
 
 Let's set up some comments to act as a roadmap in our function first.
 
-```js
+```solidity
 function validateTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, Transaction memory _transaction)
     external
     payable
@@ -37,7 +37,7 @@ function validateTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, Tran
 
 We already have a tool that will calculate fees for us called `MemoryTransactionHelper`. Let's add this to our `Transaction` import and set it up in our contract.
 
-```js
+```solidity
 import {
   Transaction,
   MemoryTransactionHelper,
@@ -46,7 +46,7 @@ import {
 
 Place the following inside our contract above the external functions
 
-```js
+```solidity
 using MemoryTransactionHelper for Transaction;
 ```
 
@@ -54,7 +54,7 @@ using MemoryTransactionHelper for Transaction;
 
 From this library, we will use a function called `totalRequiredBalance`. Set the following in our `validateTransaction` function.
 
-```js
+```solidity
 // Check for fee to pay
 uint256 totalRequiredBalance = _transaction.totalRequiredBalance();
 if (totalRequiredBalance > address(this).balance) {
@@ -67,7 +67,7 @@ if (totalRequiredBalance > address(this).balance) {
 
 Since we have a revert, let's go ahead and set our custom error under `using MemoryTransactionHelper for Transaction;`.
 
-```js
+```solidity
 error ZkMinimalAccount__NotEnoughBalance();
 ```
 
@@ -83,7 +83,7 @@ Now we can check for the signature. We will need the `encodeHash` function from 
 
 **<summary><span style="color:red">Encode Hash Function</span></summary>**
 
-```js
+```solidity
 /// @notice Calculate the suggested signed hash of the transaction,
 /// i.e. the hash that is signed by EOAs and is recommended to be signed by other accounts.
 function encodeHash(Transaction memory _transaction) internal view returns (bytes32 resultHash) {
@@ -108,7 +108,7 @@ function encodeHash(Transaction memory _transaction) internal view returns (byte
 
 Then we will need to validate the signature on the `Transaction` struct (similar to `PackedUserOperation` from our Ethereum contract.). We will need a few imports.
 
-```js
+```solidity
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
@@ -124,7 +124,7 @@ And with this we will also need to set contract to inherit `Ownable` and create 
 
 - `contract ZkMinimalAccount is IAccount, Ownable`
 
-```js
+```solidity
 constructor() Ownable(msg.sender) {}
 ```
 
@@ -140,7 +140,7 @@ Back in our function, we can now set the following variables to check the signat
 
 > ❗ **IMPORTANT** This section varies slightly from the video as there was an error that will be corrected later on.
 
-```js
+```solidity
  // Check the signature
 bytes32 txHash = _transaction.encodeHash();
 address signer = ECDSA.recover(txHash, _transaction.signature);
@@ -157,7 +157,7 @@ bool isValidSigner = signer == owner();
 
 Let's take a look at what our function looks like now. You will note that \_txHash and \_suggestedSignedHash are commented out. No need to worry about these at the moment.
 
-```js
+```solidity
 function validateTransaction(bytes32 /*_txHash*/, bytes32 /*_suggestedSignedHash*/, Transaction memory _transaction)
     external
     payable
@@ -197,7 +197,7 @@ function validateTransaction(bytes32 /*_txHash*/, bytes32 /*_suggestedSignedHash
 
 Our function is almost complete. However, we need to make sure that only the bootloader can call it. To do this, we will need to create a modifier and place it into our function. Place it below our errors in the contract.
 
-```js
+```solidity
 /*//////////////////////////////////////////////////////////////
                                MODIFIERS
 //////////////////////////////////////////////////////////////*/
@@ -216,19 +216,19 @@ Basically, this modifier is saying that if the sender is not from the `BOOTLOADE
 
 Simply paste this in the `NONCE_HOLDER_SYSTEM_CONTRACT` import that we have already added.
 
-```js
+```solidity
 BOOTLOADER_FORMAL_ADDRESS;
 ```
 
 Place this custom error with our other one at towards the top of the contract
 
-```js
+```solidity
 error ZkMinimalAccount__NotFromBootLoader();
 ```
 
 Now add `requireFromBootloader` in our function between `payable` and `returns (bytes4 magic)`. It will look like this.
 
-```js
+```solidity
 function validateTransaction(bytes32 /*_txHash*/, bytes32 /*_suggestedSignedHash*/, Transaction memory _transaction)
     external
     payable

--- a/courses/advanced-foundry/7-account-abstraction/25-execute-tx/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/25-execute-tx/+page.md
@@ -30,13 +30,13 @@ We will need to do a few things first.
 
 **Import Utils**
 
-```js
+```solidity
 import { Utils } from "lib/foundry-era-contracts/src/system-contracts/contracts/libraries/Utils.sol";
 ```
 
 **Our Execute Transaction Function**
 
-```js
+```solidity
 function executeTransaction(bytes32 /*_txHash*/, bytes32 /*_suggestedSignedHash*/, Transaction memory _transaction)
     external
     payable
@@ -59,7 +59,7 @@ Essentially, this code will perform a low-level call to an external contract usi
 
 Plug the following assembly snippet into your function.
 
-```js
+```solidity
 bool success;
 assembly {
     success := call(gas(), to, value, add(data, 0x20), mload(data), 0, 0)
@@ -71,7 +71,7 @@ if (!success) {
 
 Place our new custom errors with the others in our code.
 
-```js
+```solidity
 error ZkMinimalAccount__ExecutionFailed();
 ```
 
@@ -83,7 +83,7 @@ We've got some nice things going on with our code, but we need to make some adju
 
 **What we did in `validateTransaction`.**
 
-```js
+```solidity
 SystemContractsCaller.systemCallWithPropagatedRevert(
   uint32(gasleft()),
   address(NONCE_HOLDER_SYSTEM_CONTRACT),
@@ -96,7 +96,7 @@ SystemContractsCaller.systemCallWithPropagatedRevert(
 
 Let's add this snippet in our execution function between `bool success;` and `bytes memory data = _transaction.data;`. Wrap `bool success` and `assembly` in an else statement.
 
-```js
+```solidity
 if (to == address(DEPLOYER_SYSTEM_CONTRACT)) {
     uint32 gas = Utils.safeCastToU32(gasleft());
     SystemContractsCaller.systemCallWithPropagatedRevert(gas, to, value, data);
@@ -128,7 +128,7 @@ Just as with our `validateTransaction`, we don't want anyone to be able to call 
 - `&& msg.sender != owner()`
 - new custom revert error
 
-```js
+```solidity
 modifier requireFromBootLoaderOrOwner() {
     if (msg.sender != BOOTLOADER_FORMAL_ADDRESS && msg.sender != owner()) {
         revert ZkMinimalAccount__NotFromBootLoaderOrOwner();
@@ -139,13 +139,13 @@ modifier requireFromBootLoaderOrOwner() {
 
 Paste custom error with the others.
 
-```js
+```solidity
 error ZkMinimalAccount__NotFromBootLoaderOrOwner();
 ```
 
 Add modifier to our `execute` function.
 
-```js
+```solidity
 function executeTransaction(bytes32 /*_txHash*/, bytes32 /*_suggestedSignedHash*/, Transaction memory _transaction)
     external
     payable

--- a/courses/advanced-foundry/7-account-abstraction/26-pay-for-tx/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/26-pay-for-tx/+page.md
@@ -2,7 +2,7 @@
 
 We are very close to having our ZKsync account abstraction finished. We still need to pay for the transaction. In the `validateTransaction` function we check to see if we can pay, but now we need to actually do it. We have two possible candidates for this - `payForTransaction` and `prepareForPaymaster`. Since we aren't using a paymaster, we'll be using `payForTransaction`. 
 
-```js
+```solidity
  function payForTransaction(bytes32, /*_txHash*/ bytes32, /*_suggestedSignedHash*/ Transaction memory _transaction)
     external
     payable
@@ -20,7 +20,7 @@ Back in the `MemoryTransactionHelper` contract, there is a `payToBootloader` fun
 **<span style="color:red">MemoryTransactionHelper.sol</span>**
 
 **Pay to Bootloader Function**
-```js
+```solidity
 /// @notice Pays the required fee for the transaction to the bootloader.
 /// @dev Currently it pays the maximum amount "_transaction.maxFeePerGas * _transaction.gasLimit",
 /// it will change in the future.
@@ -38,7 +38,7 @@ function payToTheBootloader(Transaction memory _transaction) internal returns (b
 Let's use this function inside our function and set it to `bool success`. If not successful, revert.
 
 **<span style="color:red">ZkMinimalAccount.sol</span>**
-```js
+```solidity
  function payForTransaction(bytes32, /*_txHash*/ bytes32, /*_suggestedSignedHash*/ Transaction memory _transaction)
     external
     payable
@@ -52,7 +52,7 @@ Let's use this function inside our function and set it to `bool success`. If not
 
 Place the new custom errors with the others. 
 
-```js
+```solidity
 error ZkMinimalAccount__FailedToPay();
 ```
 ---

--- a/courses/advanced-foundry/7-account-abstraction/27-execute-tx-from-out/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/27-execute-tx-from-out/+page.md
@@ -17,7 +17,7 @@ Since we are beginning to use code from the bodies of `validateTransaction` and 
 
 Take the following from `validateTransaction`.
 
-```js
+```solidity
 // Call nonceholder
 // increment nonce
 // call(x, y, z) -> system contract call
@@ -50,7 +50,7 @@ return magic;
 
 Then place it in our first internal function called `_validateTransaction`. Since we are ignoring `_txHash` and `_suggestedSignedHash`, we only need to pass `_transaction` and return `bytes4 magic`.
 
-```js
+```solidity
 /*//////////////////////////////////////////////////////////////
                            INTERNAL FUNCTIONS
 //////////////////////////////////////////////////////////////*/
@@ -89,7 +89,7 @@ function _validateTransaction(Transaction memory _transaction) internal returns 
 Now, we can simply pass our new function into the body of other functions. Let's do that now in `validateTransaction`. Pass in `return _validateTransaction(_transaction);`. Now our `validateTransaction` should look like this:
 
 
-```js
+```solidity
 function validateTransaction(bytes32, /*_txHash*/ bytes32, /*_suggestedSignedHash*/ Transaction memory _transaction)
     external
     payable
@@ -105,7 +105,7 @@ function validateTransaction(bytes32, /*_txHash*/ bytes32, /*_suggestedSignedHas
 
 Let's do the same for the `executeTransaction` function. Copy the following from `executeTransaction`.
 
-```js
+```solidity
 address to = address(uint160(_transaction.to));
 uint128 value = Utils.safeCastToU128(_transaction.value);
 bytes memory data = _transaction.data;
@@ -127,7 +127,7 @@ if (to == address(DEPLOYER_SYSTEM_CONTRACT)) {
 
 Then place it in our first internal function called `_executeTransaction`. Since we are ignoring `_txHash` and `_suggestedSignedHash`, we only need to pass `_transaction`.
 
-```js
+```solidity
 function _executeTransaction(Transaction memory _transaction) internal {
     address to = address(uint160(_transaction.to));
     uint128 value = Utils.safeCastToU128(_transaction.value);
@@ -151,7 +151,7 @@ function _executeTransaction(Transaction memory _transaction) internal {
 
 Now we can pass `_executeTransaction(_transaction) ` into `executeTransaction`.
 
-```js
+```solidity
 function executeTransaction(bytes32, /*_txHash*/ bytes32, /*_suggestedSignedHash*/ Transaction memory _transaction)
     external
     payable
@@ -165,7 +165,7 @@ function executeTransaction(bytes32, /*_txHash*/ bytes32, /*_suggestedSignedHash
 
 Now that we've got that done, we can call both of our new contracts in `executeTransactionFromOutside`.
 
-```js
+```solidity
 function executeTransactionFromOutside(Transaction memory _transaction) external payable {
    _validateTransaction(_transaction);    
    _executeTransaction(_transaction);
@@ -175,7 +175,7 @@ function executeTransactionFromOutside(Transaction memory _transaction) external
 
 Now that we've got our functions just about sorted, let's go ahead and make sure our contract can receive funds. Place the following `receive` function just under the constructor. 
 
-```js
+```solidity
 receive() external payable {}
 ```
 Now our code should compile successfully with some yellow warnings. 

--- a/courses/advanced-foundry/7-account-abstraction/28-zksync-tests/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/28-zksync-tests/+page.md
@@ -8,7 +8,7 @@ Taking tests may not be much fun, but making them sure can be. Let's make some t
 - create a variable for our `ZkMinimalAccount` contract
   - to initialize a new instance of `ZkMinimalAccount` in the setUp function
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
@@ -28,7 +28,7 @@ contract ZkMinimalAccountTest is Test {
 
 Essentially, our test will be very similar to what we did in for `MinimalAccount` on Ethereum. Let's start with the `executeTransaction` function. Will start with our usual set up of **Arrange**, **Act**, and **Assert**.
 
-```js
+```solidity
 function testZkOwnerCanExecuteCommands() public {
     // Arrange
     // Act
@@ -45,27 +45,27 @@ For **Arrange** we will need:
 
 Let's start by importing ERC20Mock.
 
-```js
+```solidity
 import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 ```
 
 Next, we can create the usdc token in the variable section, and initialize a new instance of the mock in the `setUp` function. We will also need a constant `AMOUNT` variable set to 1e18.
 
 Place these with other state variables. 
-```js
+```solidity
 ERC20Mock usdc;
 
 uint256 constant AMOUNT = 1e18;
 ```
 Place this inside the `setUp` function
-```js
+```solidity
 usdc = new ERC20Mock();
 ```
 ---
 
 Our **Arrange** should look like this now. 
 
-```js
+```solidity
 // Arrange
 address dest = address(usdc);
 uint256 value = 0;
@@ -78,7 +78,7 @@ Transaction memory transaction =
 Our entire code should look like this. 
 
 ---
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 

--- a/courses/advanced-foundry/7-account-abstraction/29-tx-struct/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/29-tx-struct/+page.md
@@ -13,7 +13,7 @@ Let's get to it!
 
 Picking up where we left off, we still need to complete **ACT** and **Assert** in our `testZkOwnerCanExecuteCommands` function.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
@@ -49,7 +49,7 @@ contract ZkMinimalAccountTest is Test {
 
 Since we don't have any scripts, we'll have to make some **helper** functions. Let's add a header for them at the bottom of our code.
 
-```js
+```solidity
 /*//////////////////////////////////////////////////////////////
                                 HELPERS
 //////////////////////////////////////////////////////////////*/
@@ -63,7 +63,7 @@ The first helper function that we need to create is for unsigned transactions. L
 - a value
 - data
 
-```js
+```solidity
 /*//////////////////////////////////////////////////////////////
                                 HELPERS
 //////////////////////////////////////////////////////////////*/
@@ -80,7 +80,7 @@ function _createUnsignedTransaction(
 
 Our function returns Transaction memory. We are actually going to create this. If you've guessed that we'll need to import the `Transaction` struct, you are correct. Let's do that now. 
 
-```js
+```solidity
 import {
     Transaction
 } from "lib/foundry-era-contracts/src/system-contracts/contracts/libraries/MemoryTransactionHelper.sol";
@@ -107,12 +107,12 @@ If you go through [the struct, you'll notice that we need:](https://github.com/C
 
 As mentioned above, we need to set a couple of variables in our function. We'll place them above our `Transaction` struct that we are creating.
 
-```js
+```solidity
 uint256 nonce = vm.getNonce(address(minimalAccount));
 bytes32[] memory factoryDeps = new bytes32[](0);
 ```
 And now we can return our `Transaction`. 
-```js
+```solidity
 return Transaction({
     txType: transactionType, // type 113 (0x71).
     from: uint256(uint160(from)),
@@ -143,14 +143,14 @@ With this helper function, we can now finish **Assert** in our test function, `t
 - value is the value being passed
 - data is functionData
 
-```js
+```solidity
 Transaction memory transaction =
     _createUnsignedTransaction(minimalAccount.owner(), 113, dest, value, functionData);
 ```
 
 Here is what both of our functions should look like as of now. 
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
@@ -183,7 +183,7 @@ contract ZkMinimalAccountTest is Test {
 }
 ```
 ---
-```js
+```solidity
 /*//////////////////////////////////////////////////////////////
                                 HELPERS
 //////////////////////////////////////////////////////////////*/
@@ -222,7 +222,7 @@ function _createUnsignedTransaction(
 
 Now, all we need to do in **Act** is prank the owner. We will also need to call `executeTransaction` from our contract. Remember that it takes three arguments - `_txHash`, `_suggestedSignedHash`, and `_transaction`. Since we have commented out the first two, we'll just pass empty bytes. 
 
-```js
+```solidity
 // Act
 vm.prank(minimalAccount.owner());
 minimalAccount.executeTransaction(EMPTY_BYTES32, EMPTY_BYTES32, transaction);
@@ -230,14 +230,14 @@ minimalAccount.executeTransaction(EMPTY_BYTES32, EMPTY_BYTES32, transaction);
 
 Let's also create a constant for `EMPTY_BYTES32`. 
 
-```js
+```solidity
 bytes32 constant EMPTY_BYTES32 = bytes32(0);
 ```
 ---
 
 And finally we can complete **Assert** by checking if the balance of usdc at our address is equal to `AMOUNT`.
 
-```js
+```solidity
 // Assert
 assertEq(usdc.balanceOf(address(minimalAccount)), AMOUNT);
 ```

--- a/courses/advanced-foundry/7-account-abstraction/3-eth-setup/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/3-eth-setup/+page.md
@@ -52,7 +52,7 @@ Now that we are all set up, we can create our Ethereum contract. We will do this
 
 As always, we will set up or code with the license, pragma, and contract.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
@@ -105,7 +105,7 @@ Furthermore, we can [view the contract code directly in our browser here.](https
 
 Click on the magnifying glass icon in the top left of the screen. Type **function handleops** in the search box. You will see that it takes a `PackedUserOperation` and an `address payable`. When we send our information to the alt-mempool nodes, we need to send it so that the nodes can then send the `PackedUserOperation`, which is essentially a struct and is a standalone contract - `PackedUserOperation.sol`.
 
-```js
+```solidity
 struct PackedUserOperation {
     address sender;
     uint256 nonce;
@@ -136,19 +136,19 @@ We are going to import this interface from [eth-infinitism/account-abstraction](
 
 Head back to your terminal and run the following to install it.
 
-```js
+```bash
 forge install eth-infinitism/account-abstraction@v0.7.0 --no-commit
 ```
 
 Since eth-infinitism already has **IAccount Interface** we can simply import it into our contract.
 
-```js
+```solidity
 import { IAccount } from "lib/account-abstraction/contracts/interfaces/IAccount.sol";
 ```
 
 Next, we need to inherit it. Simply add `is IAccount` to our contract.
 
-```js
+```solidity
 contract MinimalAccount is IAccount {
     // entrypoint will eventually call this contract
 
@@ -157,7 +157,7 @@ contract MinimalAccount is IAccount {
 
 Next, click on `IAccount` to go to the contract. Scroll down until you see the `validateUserOp` function. Let's add the function to our code.
 
-```js
+```solidity
     function validateUserOp(
         PackedUserOperation calldata userOp,
         bytes32 userOpHash,
@@ -167,7 +167,7 @@ Next, click on `IAccount` to go to the contract. Scroll down until you see the `
 
 Now we need to import the `PackedUserOperation`.
 
-```js
+```solidity
 import { PackedUserOperation } from "lib/account-abstraction/contracts/interfaces/PackedUserOperation.sol";
 ```
 

--- a/courses/advanced-foundry/7-account-abstraction/31-validate-tx-test/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/31-validate-tx-test/+page.md
@@ -12,7 +12,7 @@ In this lesson, we are going to test our `_validateTransaction` function. Along 
 
 One of the key components to our `_validateTransaction` function is that it returns a 'magic' value if successful. This happens if there is a valid signer.
 
-```js
+```solidity
 address signer = ECDSA.recover(txHash, _transaction.signature);
 bool isValidSigner = signer == owner();
 if (isValidSigner) {
@@ -27,7 +27,7 @@ return magic;
 
 Let's make a test for this and call it `testZkValidateTransaction`.
 
-```js
+```solidity
 function testZkValidateTransaction() public {
     // Arrange
 
@@ -39,7 +39,7 @@ function testZkValidateTransaction() public {
 
 For **Arrange** we can copy a lot of what we have from `testZkOwnerCanExecuteCommands`.
 
-```js
+```solidity
 // Arrange
 address dest = address(usdc);
 uint256 value = 0;
@@ -61,7 +61,7 @@ The big difference is that now we need to create a signed transaction. We can do
 
 Additionally, we will need to encode hash the transaction, similar to what we did in `_validateTransaction`. For this, make sure you have `MemoryTransactionHelper` in your imports. You can place it with the `Transaction` import. It will look like this.
 
-```js
+```solidity
 import {
   Transaction,
   MemoryTransactionHelper,
@@ -70,7 +70,7 @@ import {
 
 Since we will be using a default anvil key, let's go ahead and place an account with the other constant variables.
 
-```js
+```solidity
 address constant ANVIL_DEFAULT_ACCOUNT = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 ```
 
@@ -83,7 +83,7 @@ Let's fill out our helper function now. Essentially, we will need to:
 3. attach the signature (r, s, v combined) to the transaction.
 4. return the signed transaction.
 
-```js
+```solidity
 function _signTransaction(Transaction memory transaction) internal view returns (Transaction memory) {
     bytes32 unsignedTransactionHash = MemoryTransactionHelper.encodeHash(transaction);
     uint8 v;
@@ -101,19 +101,19 @@ function _signTransaction(Transaction memory transaction) internal view returns 
 
 When we deploy our minimal account, we'll need to initialize a new instance of our default anvil account. This will allow us to sign the transaction with the anvil default key. Let's do this with the other instances in our `setUp` function.
 
-```js
+```solidity
 minimalAccount.transferOwnership(ANVIL_DEFAULT_ACCOUNT);
 ```
 
 Now that we have a signed transaction, we can use it in our **Arrange** back in our `testZkValidateTransaction` function. Place this at the bottom or **Arrange**.
 
-```js
+```solidity
 transaction = _signTransaction(transaction);
 ```
 
 Now our test function should look like this.
 
-```js
+```solidity
 function testZkValidateTransaction() public {
     // Arrange
     address dest = address(usdc);
@@ -135,13 +135,13 @@ function testZkValidateTransaction() public {
 
 We know that the caller of our validateTransaction must be the bootloader. So, we can create a vm.prank in our **Act** for this. We will of course need to import `BOOTLOADER_FORMAL_ADDRESS`.
 
-```js
+```solidity
 import { BOOTLOADER_FORMAL_ADDRESS } from "lib/foundry-era-contracts/src/system-contracts/contracts/Constants.sol";
 ```
 
 We will also need to call `validateTransaction` and pass the same arguments as we did in the **Act** for `testZkOwnerCanExecuteCommands`. The difference is that we will be setting it to `bytes4 magic`, as this is what the function returns.
 
-```js
+```solidity
 // Act
 vm.prank(BOOTLOADER_FORMAL_ADDRESS);
 bytes4 magic = minimalAccount.validateTransaction(EMPTY_BYTES32, EMPTY_BYTES32, transaction);
@@ -153,13 +153,13 @@ bytes4 magic = minimalAccount.validateTransaction(EMPTY_BYTES32, EMPTY_BYTES32, 
 
 We know from our `_validateTransaction` function that `magic = ACCOUNT_VALIDATION_SUCCESS_MAGIC`. Let's go ahead and import this from `IAccount`.
 
-```js
+```solidity
 import { ACCOUNT_VALIDATION_SUCCESS_MAGIC } from "lib/foundry-era-contracts/src/system-contracts/contracts/interfaces/IAccount.sol";
 ```
 
 Now we can simply place this in our **Assert**.
 
-```js
+```solidity
 assertEq(magic, ACCOUNT_VALIDATION_SUCCESS_MAGIC);
 ```
 
@@ -169,7 +169,7 @@ assertEq(magic, ACCOUNT_VALIDATION_SUCCESS_MAGIC);
 
 We need to do a couple of things before we run our test. First, let's add a vm.deal in our `setUp` to ensure that we have a balance.
 
-```js
+```solidity
 vm.deal(address(minimalAccount), AMOUNT);
 ```
 

--- a/courses/advanced-foundry/7-account-abstraction/33-testnet-last/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/33-testnet-last/+page.md
@@ -5,7 +5,7 @@ The final step is to deploy and send a transaction. As of the creation of this l
 First, we do need to make some updates to our `ZkMinimalAccount` contract. You may remember that our `_validateTransaction` function `returns (bytes4 magic)`. However, we forgot to do this when calling it in the `executeTransactionFromOutside` function. Let's make this update now. 
 
 **Before**
-```js
+```solidity
 function executeTransactionFromOutside(Transaction memory _transaction) external payable {
     _validateTransaction(_transaction);    
     _executeTransaction(_transaction);
@@ -13,7 +13,7 @@ function executeTransactionFromOutside(Transaction memory _transaction) external
 ```
 
 **After**
-```js
+```solidity
 function executeTransactionFromOutside(Transaction memory _transaction) external payable {
     bytes4 magic = _validateTransaction(_transaction);
     if (magic != ACCOUNT_VALIDATION_SUCCESS_MAGIC) {
@@ -25,7 +25,7 @@ function executeTransactionFromOutside(Transaction memory _transaction) external
 
 Now add the custom error with the others.
 
-```js
+```solidity
 error ZkMinimalAccount__InvalidSignature();
 ```
 ---

--- a/courses/advanced-foundry/7-account-abstraction/4-packed-user-op/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/4-packed-user-op/+page.md
@@ -4,7 +4,7 @@ In this short lesson we are going to cover the `PackedUserOperation`, which was 
 
 > ❗ **NOTE** The lines of code dealing with gas fees, limits, and verification - as well as `bytes initCode` - are to be ignored for now.
 
-```js
+```solidity
 struct PackedUserOperation {
     address sender;
     uint256 nonce;

--- a/courses/advanced-foundry/7-account-abstraction/6-entrypoint/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/6-entrypoint/+page.md
@@ -8,13 +8,13 @@ In this lesson, our main objective is to make sure that our contract can only be
 
 First, let's make sure that `validateUserOp` is only callable by the `EntryPoint` Contract. Let's import the `IEntryPoint` Interface. This will help us understand how the `EntryPoint` works and give us some valuable getter functions.
 
-```js
+```solidity
 import { IEntryPoint } from "lib/account-abstraction/contracts/interfaces/IEntryPoint.sol";
 ```
 
 Next, add `address entryPoint` as a parameter to our constructor. Then, create a state variable and set it to private immutable.
 
-```js
+```solidity
 IEntryPoint private immutable i_entryPoint;
 
 constructor(address entryPoint) Ownable(msg.sender) {
@@ -26,7 +26,7 @@ If we click into the contract we can see all of the functions that the `EntryPoi
 
 As previously mentioned, `IEntryPoint` will give us some getters. Copy and paste this header at the bottom of your code. Then, we will add some getter functions under it.
 
-```js
+```solidity
 /*//////////////////////////////////////////////////////////////
                                 GETTERS
 //////////////////////////////////////////////////////////////*/
@@ -37,7 +37,7 @@ As previously mentioned, `IEntryPoint` will give us some getters. Copy and paste
 
 Here is the getter function.
 
-```js
+```solidity
 function getEntryPoint() external view returns (address) {
         return address(i_entryPoint);
     }
@@ -45,7 +45,7 @@ function getEntryPoint() external view returns (address) {
 
 Next, we want to create a modifier called `requireFromEntryPoint`. Place it above your constructor.
 
-```js
+```solidity
 modifier requireFromEntryPoint() {
         if (msg.sender != address(i_entryPoint)) {
             revert MinimalAccount__NotFromEntryPoint();
@@ -56,13 +56,13 @@ modifier requireFromEntryPoint() {
 
 Here, if the caller of the contract is not `EntryPoint` it will revert. You may have also noticed that our modifier has a custom error. Let's place it above our state variable.
 
-```js
+```solidity
 error MinimalAccount__NotFromEntryPoint();
 ```
 
 Now we can use our modifier to make our `validateUserOp` callable exclusively from the `EntryPoint`. Let's place `requireFromEntryPoint` in our function.
 
-```js
+```solidity
 function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash, uint256 missingAccountFunds)
         external
         requireFromEntryPoint
@@ -76,7 +76,7 @@ function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash,
 
 And now we are all set for the next steps. Before we move on, let's take a look at what our code looks like so far. Take a moment to reflect on what we have gained to this point in the course. When you are ready, move on to the next lesson.
 
-```js
+```solidity
 contract MinimalAccount is IAccount, Ownable {
      /*//////////////////////////////////////////////////////////////
                                  ERRORS

--- a/courses/advanced-foundry/7-account-abstraction/7-execute/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/7-execute/+page.md
@@ -21,7 +21,7 @@ We've come a long way, but we aren't quite done yet. We still need to enable our
 
 In order for us to make all this happen, we need a new external function called `execute`. It will pass an address for the destination, uint256 for eth, and bytes calldata for ABI encoded function data. If not successful, it will revert. Be sure to add `MinimalAccount__CallFailed(result)` to the errors section of your code.
 
-```js
+```solidity
 /*//////////////////////////////////////////////////////////////
                            EXTERNAL FUNCTIONS
 //////////////////////////////////////////////////////////////*/
@@ -39,7 +39,7 @@ In order for us to make all this happen, we need a new external function called 
 
 Now, we want to allow users to call directly from their wallet to the account contract. We will need to create a modifier for this.
 
-```js
+```solidity
  modifier requireFromEntryPointOrOwner() {
         if (msg.sender != address(i_entryPoint) && msg.sender != owner()) {
             revert MinimalAccount__NotFromEntryPointOrOwner();
@@ -50,7 +50,7 @@ Now, we want to allow users to call directly from their wallet to the account co
 
 The modifier is set up in a way that will allow the **owner** or the **EntryPoint** can call our account. If not the address of either one, it will revert and give us a custom error, `MinimalAccount__NotFromEntryPointOrOwner`. Let's place it with the other errors.
 
-```js
+```solidity
 /*//////////////////////////////////////////////////////////////
                                  ERRORS
 //////////////////////////////////////////////////////////////*/
@@ -65,7 +65,7 @@ The modifier is set up in a way that will allow the **owner** or the **EntryPoin
 
 The last thing we need to do now is add a `receive` function. We will make it `external payable` so that the contract can accept funds from our `_payPrefund` function to pay for transactions. Place `receive() external payable {}` just below our constructor, like so:
 
-```js
+```solidity
 constructor(address entryPoint) Ownable(msg.sender) {
         i_entryPoint = IEntryPoint(entryPoint);
     }

--- a/courses/advanced-foundry/7-account-abstraction/8-deploy-ethereum/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/8-deploy-ethereum/+page.md
@@ -8,7 +8,7 @@ Let's start by naming our first script in the `script` folder. Name it `DeployMi
 
 **<span style="color:red">DeployMinimal.s.sol</span>**
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
@@ -26,7 +26,7 @@ If you remember(or go back) to our MinimalAccount, the constructor passes `addre
 
 **<span style="color:red">MinimalAccount.sol</span>**
 
-```js
+```solidity
 constructor(address entrypoint)
 ```
 
@@ -36,7 +36,7 @@ Let's set this up in our `HelperConfig.s.sol`.
 
 **<span style="color:red">HelperConfig.s.sol</span>**
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
@@ -103,13 +103,13 @@ Now that we have our `HelperConfig`, let's import it in `DeployMinimal.s.sol`.
 
 **<span style="color:red">DeployMinimal.s.sol</span>**
 
-```js
+```solidity
 import { HelperConfig } from "script/HelperConfig.s.sol";
 ```
 
 Then we need to add it to our `deployMinimalAccount` function.
 
-```js
+```solidity
 function deployMinimalAccount() public returns (HelperConfig, MinimalAccount) {
     HelperConfig helperConfig = new HelperConfig();
     HelperConfig.NetworkConfig memory config = helperConfig.getConfig();

--- a/courses/advanced-foundry/7-account-abstraction/9-owner-execute-test/+page.md
+++ b/courses/advanced-foundry/7-account-abstraction/9-owner-execute-test/+page.md
@@ -28,7 +28,7 @@ Now that we've got some scripts written, we need to do some testing. Let's creat
 
 **<span style="color:red">MinimalAccountTest.t.sol</span>**
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
@@ -71,7 +71,7 @@ In a nutshell, we are going to simulate being the alt-mempool. To get started, w
 
 **<span style="color:red">MinimalAccount.sol</span>**
 
-```js
+```solidity
 function execute(address dest, uint256 value, bytes calldata functionData) external requireFromEntryPointOrOwner {
     (bool success, bytes memory result) = dest.call{value: value}(functionData);
     if (!success) {
@@ -91,7 +91,7 @@ The owner should be able to call this function and send a transaction.
 
 Let's write our test and call it `testOwnerCanExecuteCommands`. Set it up with **Arrange**, **Act**, and **Assert** comments.
 
-```js
+```solidity
 function testOwnerCanExecuteCommands() public {
     //Arrange
 
@@ -103,13 +103,13 @@ function testOwnerCanExecuteCommands() public {
 
 The first thing we will need now is a mock ERC20. Let's import this from **OpenZeppelin**.
 
-```js
+```solidity
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 ```
 
 Next, create another state variable `ERC20Mock usdc` , and assign `new ERC20Mock()` to usdc in the `setUp` function.
 
-```js
+```solidity
 contract MinimalAccountTest is Test {
     HelperConfig helperConfig;
     MinimalAccount minimalAccount;
@@ -127,7 +127,7 @@ With that, we can move back to our test and do a **USDC Mint**. If you go into E
 
 **<span style="color:red">ERC20Mock.sol</span>**
 
-```js
+```solidity
 function mint(address account, uint256 amount) external {
     _mint(account, amount);
 }
@@ -141,7 +141,7 @@ Let's add what we need from our `execute` function and `ERC20Mock mint` to **Ass
 
 **<span style="color:red">MinimalAccountTest.t.sol</span>**
 
-```js
+```solidity
 //Assert
 assertEq(usdc.balanceOf(address(minimalAccount)), 0);
     address dest = address(usdc);
@@ -151,7 +151,7 @@ assertEq(usdc.balanceOf(address(minimalAccount)), 0);
 
 Next, in **Act**, we will prank the owner.
 
-```js
+```solidity
 // Act
 vm.prank(minimalAccount.owner());
 minimalAccount.execute(dest, value, functionData);
@@ -159,14 +159,14 @@ minimalAccount.execute(dest, value, functionData);
 
 So far, our test function should mint some mock ERC20 to our `minimalAccount`. Before we go any further, be sure to set a constant state variable for AMOUNT - `uint256 constant AMOUNT = 1e18;`.
 
-```js
+```solidity
 // Assert
 assertEq(usdc.balanceOf(address(minimalAccount)), AMOUNT);
 ```
 
 Let's go back and pass the following in abi.encodeWithSelector(ERC20Mock.mint.selector) of the **Assert** section - `address(minimalAccount), AMOUNT `. Our completed function should now look like this:
 
-```js
+```solidity
 function testOwnerCanExecuteCommands() public skipZkSync {
     // Arrange
     assertEq(usdc.balanceOf(address(minimalAccount)), 0);
@@ -184,7 +184,7 @@ function testOwnerCanExecuteCommands() public skipZkSync {
 
 **Drum Roll!** Let's run our test now. Run the following command in your terminal.
 
-```js
+```bash
 forge test --mt testOwnerCanExecuteCommands -vvv
 ```
 
@@ -194,7 +194,7 @@ forge test --mt testOwnerCanExecuteCommands -vvv
 
 **<span style="color:red">HelperConfig.sol</span>**
 
-```js
+```solidity
 function getOrCreateAnvilEthConfig() public returns (NetworkConfig memory) {
     if (localNetworkConfig.account != address(0)) {
         return localNetworkConfig;
@@ -206,7 +206,7 @@ function getOrCreateAnvilEthConfig() public returns (NetworkConfig memory) {
 
 First, add a new constant variable, `FOUNDRY_DEFAULT_WALLET`, to the state variables.
 
-```js
+```solidity
 address constant FOUNDRY_DEFAULT_WALLET = 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38;
 ```
 
@@ -216,7 +216,7 @@ address constant FOUNDRY_DEFAULT_WALLET = 0x1804c8AB1F12E6bbf3894d4083f33e07309d
 
 **<span style="color:red">MinimalAccount.sol**
 
-```js
+```solidity
 function execute(address dest, uint256 value, bytes calldata functionData) external requireFromEntryPointOrOwner {
     (bool success, bytes memory result) = dest.call{value: value}(functionData);
     if (!success) {
@@ -229,7 +229,7 @@ Back over in the `HelperConfig`, insert the following code into our function.
 
 **<span style="color:red">HelperConfig.sol</span>**
 
-```js
+```solidity
 // deploy mocks
 
 return NetworkConfig({
@@ -240,7 +240,7 @@ return NetworkConfig({
 
 Let's see where we are now.
 
-```js
+```bash
 forge test --mt testOwnerCanExecuteCommands -vvv
 ```
 
@@ -258,13 +258,13 @@ Let's create a makeAddr() first. Add the following to your state variables in th
 
 <span style="color:red">**MinimalAccountTest.t.sol**</span>
 
-```js
+```solidity
 address randomuser = makeAddr("randomUser");
 ```
 
 Now we are ready to write our next test - `testNonOwnerCannotExecuteCommands`. The **Arrange** will be the same as the previous test, but we won't have an **Assert**. The biggest change will be in our **Act**. Instead of `minimalAccount.owner`, we will use `randomuser` in `vm.prank`. Additionally, we will add `vm.expectRevert` as our contract is expected to revert if not the owner.
 
-```js
+```solidity
 function testNonOwnerCannotExecuteCommands() public {
     // Arrange
     assertEq(usdc.balanceOf(address(minimalAccount)), 0);
@@ -280,7 +280,7 @@ function testNonOwnerCannotExecuteCommands() public {
 
 Run forge test again and it should pass.
 
-```js
+```bash
 forge test --mt testOwnerCanExecuteCommands -vvv
 ```
 

--- a/courses/advanced-foundry/8-daos/4-governance-tokens/+page.md
+++ b/courses/advanced-foundry/8-daos/4-governance-tokens/+page.md
@@ -14,7 +14,7 @@ As mentioned in the previous closing remarks, I suspect this will mostly be revi
 
 Copying this into our contract and we're already almost set (I've adjusted below to utilize named imports).
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 // Compatible with OpenZeppelin Contracts ^5.0.0
 pragma solidity ^0.8.20;
@@ -52,7 +52,7 @@ Let's go over how this differs from a standard ERC20. Primarily it's the same ba
 
 From the documentation:
 
-```js
+```solidity
 /* @dev Implementation of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in
  * https://eips.ethereum.org/EIPS/eip-2612[EIP-2612].
 ```

--- a/courses/advanced-foundry/8-daos/5-governor-contract/+page.md
+++ b/courses/advanced-foundry/8-daos/5-governor-contract/+page.md
@@ -34,7 +34,7 @@ Upgradeability - Our bells from last lesson should be going off! This includes p
 
 We'll keep everything default for this exercise, let's just copy the provided Governor contract into our own file `src/MyGovernor.sol`.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 // Compatible with OpenZeppelin Contracts ^5.0.0
 pragma solidity ^0.8.20;
@@ -155,7 +155,7 @@ This is the core of the governance system. The governor tracks proposals via the
 
 Proposals exist as fairly simple structs:
 
-```js
+```solidity
 struct ProposalCore {
     // --- start retyped from Timers.BlockNumber at offset 0x00 ---
     uint64 voteStart;
@@ -172,7 +172,7 @@ struct ProposalCore {
 
 Each proposal's state is tracked through the `state` function. This references the aforementioned proposal mapping and displays various properties including if it was executed, if quorum was reached etc. This is the function that many front ends will call to display proposal details.
 
-```js
+```solidity
 function state(uint256 proposalId) public view virtual override returns (ProposalState) {
     ProposalCore storage proposal = _proposals[proposalId];
 
@@ -212,7 +212,7 @@ function state(uint256 proposalId) public view virtual override returns (Proposa
 
 One of the most important functions in Governor.sol is going to be `propose`, this is the function DAO members will call to submit a proposal for voting, the parameters passed here are very specific.
 
-```js
+```solidity
 function propose(
     address[] memory targets,
     uint256[] memory values,
@@ -233,7 +233,7 @@ The proposal function takes these inputs and will hash them, generating a unique
 
 Another integral function within this contract is `execute` which we see takes largely the same parameters as `propose`. Within execute, these passed parameters are hashed to determine the valid proposalId to execute. Some checks are performed before the internal \_execute is called and we can see the same low-level functionality we used to call arbitrary functions, in previous lessons.
 
-```js
+```solidity
 /**
  * @dev Internal execution mechanism. Can be overridden to implement different execution mechanism
  */
@@ -254,7 +254,7 @@ function _execute(
 
 The last major function I'll detail is \_castVote. There are a number of derivated such as castVoteWithReason, castVoteBySig etc, but ultimately they boil down to this \_castVote logic.
 
-```js
+```solidity
  /**
  * @dev Internal vote casting mechanism: Check that the vote is pending, that it has not been cast yet, retrieve
  * voting weight using {IGovernor-getVotes} and call the {_countVote} internal function.
@@ -300,7 +300,7 @@ An extension contract that allows configuration of things like voting delay, vot
 
 This extension implements a simplified vote counting mechanism by which each proposal is assigned a ProposalVote struct in which forVotes, againstVotes and abstainVotes are tallied.
 
-```js
+```solidity
 struct ProposalVotes {
     uint256 againstVotes;
     uint256 forVotes;
@@ -326,7 +326,7 @@ This functionality is important for a number of reasons, two major ones that com
 
 So, with a better understanding of all the functionality our DAO has under-the-hood, the constructor we copied over from the Contract Wizard should make a lot of sense to us.
 
-```js
+```solidity
 constructor(IVotes _token, TimelockController _timelock)
     Governor("MyGovernor")
     GovernorSettings(7200, /* 1 day */ 50400, /* 1 week */ 0)
@@ -344,7 +344,7 @@ The TimelockController is going to be the last contract we need to write, actual
 
 We don't get a Contract Wizard shortcut this time, but it won't be too difficult to build this one out ourselves, we _can_ still leverage the OpenZeppelin governance library.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;

--- a/courses/advanced-foundry/8-daos/6-tests/+page.md
+++ b/courses/advanced-foundry/8-daos/6-tests/+page.md
@@ -10,7 +10,7 @@ _Follow along with this video._
 
 Let's jump right into writing our tests. Begin with creating `test/MyGovernorTest.t.sol`. We're going to have one giant test to show this whole process end to end, let's start with the usual boilerplate!
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -35,7 +35,7 @@ contract MyGovernorTest is Test {
 
 We've more of our imported contracts that we'll need to deploy, but at this point we should consider the minting of our GovToken, you can choose to include the minting of your initial supply within the constructor of your GovToken ERC20, but I'm just going to add a mint function to it.
 
-```js
+```solidity
 function mint(address _to, uint256 _amount) public {
     _mint(_to, _amount);
 }
@@ -44,7 +44,7 @@ function mint(address _to, uint256 _amount) public {
 > ❗ **IMPORTANT**
 > You probably **_don't_** want a function that anyone can call in order to mint your governance token, we're just applying this here to make our testing easier.
 
-```js
+```solidity
 contract MyGovernorTest is Test {
     MyGovernor governor;
     Box box;
@@ -63,7 +63,7 @@ contract MyGovernorTest is Test {
 
 Something commonly overlooked when writing tests this way is that, just because our user has minted tokens, doesn't mean they have voting power. It's necessary to call the delegate function to assign this weight to the user who minted.
 
-```js
+```solidity
 function setUp() public {
     govToken = new GovToken();
     govToken.mint(USER, INITIAL_SUPPLY);
@@ -76,7 +76,7 @@ Now we can deploy our Timelock contract, we'll need both the Timelock and the go
 
 Once the Timelock has been deployed, we can finally deploy our governor contract.
 
-```js
+```solidity
 contract MyGovernorTest is Test {
     MyGovernor governor;
     Box box;
@@ -107,7 +107,7 @@ contract MyGovernorTest is Test {
 
 Now's the point where we want to tighten up who is able to control what aspects of the DAO protocol. The Timelock contract we're using contains a number of roles which we can set on deployment. For example, we only want our governor to be able to submit proposals to the timelock, so this is something we want want to configure explicitly after deployment. Similarly the `admin` role is defaulted to the address which deployed our timelock, we absolutely want this to be our governor to avoid centralization.
 
-```js
+```solidity
 function setUp() public {
     govToken = new GovToken();
     govToken.mint(USER, INITIAL_SUPPLY);
@@ -130,14 +130,14 @@ function setUp() public {
 
 The last thing we need to consider in our setUp is our little Box contract! Once deployed, we need to assure that the `timelock` is set as the owner of this protocol. If you recall, the store function of our Box contract is access controlled. This is meant to be called by only our DAO. But, because our DAO (the governor contract) must always check with the timelock before executing anything, the timelock is what must be set as the address able to call functions on our protocol.
 
-```js
+```solidity
 box = new Box();
 box.transferOwnership(address(timelock));
 ```
 
 Amazing! At this point we can jump right into our first simple test. Let's assure that only our timelock can call the `store` function.
 
-```js
+```solidity
 function testCantUpdateBoxWithoutGovernance() public{
     vm.expectRevert();
     box.store(1);
@@ -156,19 +156,19 @@ Beautiful!
 
 Alright, the next one will be a giant test function. This should demonstrate from a coding standing point how a DAO function from start to end. Let's go!
 
-```js
+```solidity
 function testGovernanceUpdatesBox() public {}
 ```
 
 The function we're going to call is store, of course, so we'll declare the value we expect to pass. Beyond this, the first thing we'll need to do to kick off a vote is submit a proposal.
 
-```js
+```solidity
 function propose(addresses[] memory targets, uint256[] memory values, bytes[] memory calldatas, string memory description) public virtual override returns (uint256){...}
 ```
 
 Many of these parameters we should already know. The target of our proposed function call is going to be our Box contract address, the value we're passing with the function call is zero, and the calldata is going to be our function signature encoded with our data. All things we've done before!
 
-```js
+```solidity
 function testGovernanceUpdatesBox() public {
     uint256 valueToStore = 420;
     string memory description = "Update box value to 420 for clout";
@@ -185,7 +185,7 @@ function testGovernanceUpdatesBox() public {
 
 From this point we can call our propose function! propose returns a uint256 proposalId, which will be important for the next stages of our test.
 
-```js
+```solidity
 function testGovernanceUpdatesBox() public {
     uint256 valueToStore = 420;
     string memory description = "Update box value to 420 for clout";
@@ -202,7 +202,7 @@ function testGovernanceUpdatesBox() public {
 
 It might be a good idea for our test to check the state of the proposal that's been submitted! We can do this by calling the `state` function with our proposalId. This call will return a uint256 which pertains to an index of the ProposalState enum.
 
-```js
+```solidity
 abstract contract IGovernor is IERC165 {
     enum ProposalState {
         Pending,
@@ -220,14 +220,14 @@ abstract contract IGovernor is IERC165 {
 
 We can check the state with the following:
 
-```js
+```solidity
 // View the State
 console.log("Proposal State 1: ", uint256(governor.state(proposalId)));
 ```
 
 We would expect this to return `0`, which indicates that the proposal is pending, this is because the Timelock Controller is enforcing a delay before voting on a proposal. We'll need to simulate the passage of time using the vm.warp and vm.roll cheatcodes Foundry offers before we can see our state change. We'll also need to declare a VOTING_DELAY constant and assign this to 1. This will represent 1 block delay before voting is authorized.
 
-```js
+```solidity
 contract MyGovernorTest is Test {
     ...
     uint256 public constant VOTING_DELAY = 1 // # of blocks until vote is active
@@ -247,7 +247,7 @@ With this, we can finally cast a vote on the proposal! I'm going to leverage the
 
 From the GovernorCountingSimple extension, the voting types are defined as:
 
-```js
+```solidity
 enum VoteType{
     Against, // 0
     For,     // 1
@@ -257,7 +257,7 @@ enum VoteType{
 
 So, in order for our test to vote _in favour_ of a proposal, we need to pass `1` as our vote parameter in the function we're calling.
 
-```js
+```solidity
 // 2. Vote
 string memory reason = "420 is cool number. Cool number for cool people.";
 
@@ -267,7 +267,7 @@ governor.castVoteWithReason(proposalId, 1, reason);
 
 Now that the votes are cast, we'll need to advance time again. Our voting period has been defaulted to 1 week (50400 blocks), let's create this constant and move time forward accordingly.
 
-```js
+```solidity
 contract MyGovernorTest is Test {
     ...
     uint256 public constant VOTING_PERIOD = 50400;
@@ -284,7 +284,7 @@ Once the VOTING_PERIOD has elapsed, a successful proposal needs to be queued bef
 
 After a proposal is queued, we'll of course need to advance time again to account for our Timelock's configured MIN_DELAY. This is the opportunity for stakeholders to exit their position if they don't agree with the DAOs decision!
 
-```js
+```solidity
 // 3. Queue the Proposal
 bytes32 descriptionHash = keccak256(abi.encodePacked(description));
 governor.queue(targets, values, calldatas, descriptionHash);
@@ -295,14 +295,14 @@ vm.roll(block.number + MIN_DELAY + 1);
 
 FINALLY, after much anxiety and bated breath, our proposal hits the execute phase. Much like the queue function, the execute function requires the same parameters to verify the state of our proposalId before execution.
 
-```js
+```solidity
 // 4. Execute the Proposal
 governor.execute(targets, values, calldatas, descriptionHash);
 ```
 
 Once executed, we have to verify that our proposed change _actually_ happened! We can now call the `retrieve` function on our Box and assert that the returned value is what we expect it to be!
 
-```js
+```solidity
 console.log("Box Value: ", box.retrieve());
 assert(box.retrieve() == valueToStore);
 ```
@@ -312,7 +312,7 @@ I know this written portion has been long and broken up (this test function is h
 <details>
 <summary>testGovernanceUpdatesBox</summary>
 
-```js
+```solidity
 function testGovernanceUpdatesBox() public {
     uint256 valueToStore = 420;
     string memory description = "Update box value to 420 for clout";

--- a/courses/advanced-foundry/8-daos/7-recap/+page.md
+++ b/courses/advanced-foundry/8-daos/7-recap/+page.md
@@ -18,7 +18,7 @@ As a bonus piece of content, Harrison with Gaslight shares his advice on increas
 
 To showcase a common waste of gas in smart contract development, we reference a simple air drop contract:
 
-```js
+```solidity
 contract BadAirdrop {
     address token;
     uint256 public transfers;
@@ -50,7 +50,7 @@ We're then iterating through the array again to transfer from the contract to th
 
 There are lots of improvements possible here. Let's look at a more ideal example.
 
-```js
+```solidity
 contract GoodAirdrop {
     address public immutable token;
     uint256 public transfers;

--- a/courses/advanced-foundry/9-security/4-top-tools/+page.md
+++ b/courses/advanced-foundry/9-security/4-top-tools/+page.md
@@ -32,7 +32,7 @@ Manual Review is arguably _the most important_ aspect of an audit. Reading the d
 
 For example:
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.18;
@@ -94,7 +94,7 @@ Once open in it's own instance of VSCode, we should see a number of contracts co
 
 To start with one the the simpler onces, `CaughtWithManualReview.sol`, this bug is meant to be identified simply by reviewing the code manually.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
@@ -114,7 +114,7 @@ By reading the comments/documentation provided, we can see that this function is
 
 Let's look at `CaughtWithTest.sol`. This is a contract we've seen before.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
@@ -132,7 +132,7 @@ We expect the newNumber passed to this function would be assigned to our number 
 
 Next up, `CaughtWithSlither.sol`. We can use Slither, a static analysis tool to catch the issue here.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
@@ -170,7 +170,7 @@ Look how easy that is. It won't catch everything, but Slither is one of those to
 
 The `CaughtWithFuzz.sol` contract looks insane, but we have a clearly defined invariant, `should never return 0`. The fuzz testing we applied in earlier lessons would be perfect for this.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
@@ -219,7 +219,7 @@ contract CaughtWithFuzz {
 
 A clever fuzz test like this would have no issues catching vulnerabilities in a complex function as above:
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
@@ -248,7 +248,7 @@ Our fuzz test identifies the counter-example of 1265!
 
 What about `CaughtWithStatefulFuzz.sol`? Well, in this contract a stateless fuzz test won't cut it. The invariant of `should never return zero` is only breakable through subsequent function calls to the contract, with the first altering contract in state, such that the second call breaks our invariant.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
@@ -272,7 +272,7 @@ contract CaughtWithStatefulFuzz {
 
 In the above, if changeValue is called with 0, and then doMoreMathAgain is also called with 0, our invariant will break. We'll need a stateful fuzz suite to catch this one.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
@@ -305,7 +305,7 @@ We can see here the running our stateful fuzz test `invariant_testMathDoesntRetu
 
 Lastly, we have `CaughtWithSymbolic.sol` where we can actually just use the solidity compiler to try and catch some bugs.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 

--- a/courses/advanced-foundry/9-security/6-formal-verification/+page.md
+++ b/courses/advanced-foundry/9-security/6-formal-verification/+page.md
@@ -16,7 +16,7 @@ These are the _bare minimum_ of testing in Web3 security. Unit test will propose
 
 For example, take the contract below.
 
-```js
+```solidity
 // SPDX-License-Identifier
 pragma solidity ^0.8.13;
 
@@ -31,7 +31,7 @@ contract CaughtWithTest {
 
 In a situation like this, if the expectation was that `number` is being set to `newNumber`, a unit test would catch this. In our unit test, we would assert our expected outcome and pass a test value to our function:
 
-```js
+```solidity
 function testSetNumber() public {
     uint256 myNumber = 55;
     caughtWithTest.setNumber(myNumber);
@@ -53,7 +53,7 @@ An invariant is a property of a protocol which much always hold true. Fuzz testi
 
 Consider a slightly more complex contract such as below.
 
-```js
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -73,7 +73,7 @@ In this simple example, we can easily see that if we pass `2` as an argument to 
 
 Here's an example of a fuzz test we could perform:
 
-```js
+```solidity
     ...
     function testIAlwaysGetZeroFuzz(uint256 data) public {
         myContract.doStuff(data);
@@ -91,7 +91,7 @@ Unit testing and fuzz testing as examples of **_dynamic tests_**, this is when c
 
 Alternatively to this, we have static analysis as a tool available to us. In static analysis testing, a tool such as [**Slither**](https://github.com/crytic/slither) or [**Aderyn**](https://github.com/Cyfrin/aderyn), will review the code and identify vulnerabilities based on things like layout, ordering and syntax.
 
-```js
+```solidity
 function withdraw() external {
     uint256 balance = balances[msg.sender];
     require(balance > 0);
@@ -119,7 +119,7 @@ We'll only really cover Symbolic Execution in this course. If you want to dive d
 
 At a high-level, Symbolic Execution models each path in the code mathematically to identify if any path results in the breaking of an asserted property of the system.
 
-```js
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 


### PR DESCRIPTION
Changing solidity code snippets from js to solidity in advanced foundry course, for instance, from:

```js
contract MoodNft is ERC721 {
    uint256 private s_tokenCounter;
    string private s_sadSvgImageUri;
    string private s_happySvgImageUri;

    constructor(string memory sadSvgImageUri, string memory happySvgImageUri) ERC721("Mood NFT", "MN"){
        s_sadSvgImageUri = sadSvgImageUri;
        s_happySvgImageUri = happySvgImageUri
    }
}
```

to 

```solidity
contract MoodNft is ERC721 {
    uint256 private s_tokenCounter;
    string private s_sadSvgImageUri;
    string private s_happySvgImageUri;

    constructor(string memory sadSvgImageUri, string memory happySvgImageUri) ERC721("Mood NFT", "MN"){
        s_sadSvgImageUri = sadSvgImageUri;
        s_happySvgImageUri = happySvgImageUri
    }
}
```