### PR TITLE
docs: Fixed formatting issue in the "NOTE" section

### DIFF
--- a/courses/foundry/4-smart-contract-lottery/1-introduction/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/1-introduction/+page.md
@@ -8,7 +8,7 @@ _Follow along with the video_
 
 Welcome to Section 9 of this course! You can code along by following the [GitHub repo](https://github.com/Cyfrin/foundry-smart-contract-lottery-cu) associated with this section. This project will be a valuable addition to your portfolio, as we'll develop a **Verifiably Random Lottery Smart Contract** that contains a lot of best coding practices.
 
-> 🗒️ **NOTE**:br
+> 🗒️ **NOTE**:
 > We won't be deploying this to ZkSync because of current integration constraints.
 
 In this lesson, we will cover **events**, **true random numbers**, **modules**, and **automation**. You can preview the final project by cloning the repository and checking the `makefile`, which lists all the specific versions of dependencies needed to compile our contract.


### PR DESCRIPTION
<img width="724" alt="Снимок экрана 2025-02-23 в 14 47 54" src="https://github.com/user-attachments/assets/f4a51075-f47b-42e6-a6b8-f4e8cd20db6e" />

I noticed a small formatting issue in the "NOTE" section, where there was an unnecessary `:br` after the note.
I’ve removed it, making the text cleaner and more readable. 
