### PR TITLE
Foundry-advanced: DAO - video 3 | adding note that Ownable needs an initial owner address

### DIFF
--- a/courses/advanced-foundry/8-daos/3-setup/+page.md
+++ b/courses/advanced-foundry/8-daos/3-setup/+page.md
@@ -52,6 +52,12 @@ remappings = ["@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"]
 
 The start of our contract should look very familiar.
 
+> ❗ **NOTE**
+> For version 5 of OpenZeppelin's Ownable contract, we need to pass an address
+> in the constructor. We have to modify our code to account for this when
+> running `forge build` so that our project will not error. Like this:
+> `contract Box is Ownable(initialOwner) {}`
+
 ```js
 // SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
As in defi section, I've added the same note for Ownable from Openzeppelin:

You can check  here:
https://github.com/Cyfrin/Updraft/blob/main/courses/advanced-foundry/3-develop-defi-protocol/4-defi-decentralized-stablecoin/%2Bpage.md 
