### PR TITLE
Foundry-advanced: DAO - video 4 | missing import; renaming MyToken to GovToken;

### DIFF
--- a/courses/advanced-foundry/8-daos/4-governance-tokens/+page.md
+++ b/courses/advanced-foundry/8-daos/4-governance-tokens/+page.md
@@ -22,9 +22,10 @@ pragma solidity ^0.8.20;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import {ERC20Votes} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+import {Nonces} from "@openzeppelin/contracts/utils/Nonces.sol";
 
 contract GovToken is ERC20, ERC20Permit, ERC20Votes {
-    constructor() ERC20("GovToken", "GT") ERC20Permit("MyToken") {}
+    constructor() ERC20("GovToken", "GT") ERC20Permit("GovToken") {}
 
     // The following functions are overrides required by Solidity.
 


### PR DESCRIPTION
## Foundry-advanced: DAO - video 4 

-  missing Nonces import 
- renaming MyToken to GovToken