### PR TITLE
Introduction to Python and Vyper, Section 2: Fix character encoding in written lesson

### DIFF
--- a/courses/intro-python-vyper-smart-contract-development/2-remix-coffee/13-staticcall/+page.md
+++ b/courses/intro-python-vyper-smart-contract-development/2-remix-coffee/13-staticcall/+page.md
@@ -1,6 +1,6 @@
 ## Calling External Contracts in Vyper
 
-We are going to make sure that we use the proper keyword when we call external contracts. In Solidity, it�s pretty straightforward. We just call an external contract. However, iVyperer, we need to use a specific keyword. If we are calling a view function or don�t want to change any state, we use `staticcall`. Otherwise, we use `extcall`, which stands for external call.
+We are going to make sure that we use the proper keyword when we call external contracts. In Solidity, it's pretty straightforward. We just call an external contract. However, Vyper, we need to use a specific keyword. If we are calling a view function or don't want to change any state, we use `staticcall`. Otherwise, we use `extcall`, which stands for external call.
 
 We will use the following code block to demonstrate how to call an external contract using `staticcall` in Vyper.
 


### PR DESCRIPTION
Changes
- � should be '
- iVyperer should be Vyper