### PR TITLE
Introduction to Python and Vyper, Section 1: Fix demo code in written lesson

### DIFF
--- a/courses/intro-python-vyper-smart-contract-development/1-favorites/31-workshop-pt-2/+page.md
+++ b/courses/intro-python-vyper-smart-contract-development/1-favorites/31-workshop-pt-2/+page.md
@@ -26,7 +26,7 @@ list_of_numbers: public(uint256[5])
 list_of_people: public(Person[5])
 list_of_people_index: uint256
 
-name_to_favorite_number: HashMap(String[100], uint256)
+name_to_favorite_number: HashMap[String[100], uint256]
 
 @deploy
 def __init__():
@@ -36,6 +36,7 @@ def __init__():
 def store(favorite_number: uint256):
     self.my_favorite_number = favorite_number
 
+@external
 @view
 def retrieve() -> uint256:
     return self.my_favorite_number


### PR DESCRIPTION
- HashMap uses `[]` and not `()`. Vyper compiler errors when using `()`.
- Function with `@view` decorator requires additional decorators, or else Vyper compiler errors.
