### PR TITLE
Changed links to redirect to github if clicked from Updraft

### DIFF
--- a/courses/rocket-pool-reth-integration/2-understanding-reth/13-exercise-eth-to-reth-exchange-rate/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/13-exercise-eth-to-reth-exchange-rate/+page.md
@@ -1,6 +1,6 @@
 # `SwapRocketPool.calcEthToReth` exercise
 
-Write your code inside the [`SwapRocketPool` contract](../src/exercises/SwapRocketPool.sol)
+Write your code inside the [`SwapRocketPool` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/SwapRocketPool.sol)
 
 This exercise is design to implement a function that will calculate the exchange rate from ETH to rETH minus the deposit fee.
 

--- a/courses/rocket-pool-reth-integration/2-understanding-reth/15-exercise-reth-to-eth-exchange-rate/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/15-exercise-reth-to-eth-exchange-rate/+page.md
@@ -1,6 +1,6 @@
 # `SwapRocketPool.calcRethToEth` exercise
 
-Write your code inside the [`SwapRocketPool` contract](../src/exercises/SwapRocketPool.sol)
+Write your code inside the [`SwapRocketPool` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/SwapRocketPool.sol)
 
 This exercise is design to implement a function that will calculate the exchange rate from rETH to ETH.
 

--- a/courses/rocket-pool-reth-integration/2-understanding-reth/17-exercise-reth-availability/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/17-exercise-reth-availability/+page.md
@@ -1,6 +1,6 @@
 # `SwapRocketPool.getAvailability` exercise
 
-Write your code inside the [`SwapRocketPool` contract](../src/exercises/SwapRocketPool.sol)
+Write your code inside the [`SwapRocketPool` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/SwapRocketPool.sol)
 
 The goal of this exercise is to learn how to get availability of minting rETH.
 

--- a/courses/rocket-pool-reth-integration/2-understanding-reth/19-exercise-reth-deposit-delay/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/19-exercise-reth-deposit-delay/+page.md
@@ -1,6 +1,6 @@
 # `SwapRocketPool.getDepositDelay` exercise
 
-Write your code inside the [`SwapRocketPool` contract](../src/exercises/SwapRocketPool.sol)
+Write your code inside the [`SwapRocketPool` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/SwapRocketPool.sol)
 
 The goal of this exercise is to learn how to directly get data from the `RocketStorage` contract.
 

--- a/courses/rocket-pool-reth-integration/2-understanding-reth/21-exercise-last-deposit-block/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/21-exercise-last-deposit-block/+page.md
@@ -1,6 +1,6 @@
 # `SwapRocketPool.getLastDepositBlock` exercise
 
-Write your code inside the [`SwapRocketPool` contract](../src/exercises/SwapRocketPool.sol)
+Write your code inside the [`SwapRocketPool` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/SwapRocketPool.sol)
 
 The goal of this exercise is to learn how to directly get data from the `RocketStorage` contract.
 

--- a/courses/rocket-pool-reth-integration/2-understanding-reth/23-exercise-rocket-pool-swap-eth-to-reth/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/23-exercise-rocket-pool-swap-eth-to-reth/+page.md
@@ -1,6 +1,6 @@
 # `SwapRocketPool.swapEthToReth` exercise
 
-Write your code inside the [`SwapRocketPool` contract](../src/exercises/SwapRocketPool.sol)
+Write your code inside the [`SwapRocketPool` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/SwapRocketPool.sol)
 
 This exercise is designed to gain experience minting rETH.
 

--- a/courses/rocket-pool-reth-integration/2-understanding-reth/25-exercise-rocket-pool-swap-reth-to-eth/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/25-exercise-rocket-pool-swap-reth-to-eth/+page.md
@@ -1,6 +1,6 @@
 # `SwapRocketPool.swapRethToEth` exercise
 
-Write your code inside the [`SwapRocketPool` contract](../src/exercises/SwapRocketPool.sol)
+Write your code inside the [`SwapRocketPool` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/SwapRocketPool.sol)
 
 This exercise is designed to gain experience redeeming ETH from rETH.
 

--- a/courses/rocket-pool-reth-integration/2-understanding-reth/27-exercise-uniswap-v3-swap-weth-to-reth/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/27-exercise-uniswap-v3-swap-weth-to-reth/+page.md
@@ -1,6 +1,6 @@
 # `SwapUniswapV3.swapRethToWeth` exercise
 
-Write your code inside the [`SwapUniswapV3` contract](../src/exercises/SwapUniswapV3.sol)
+Write your code inside the [`SwapUniswapV3` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/SwapUniswapV3.sol)
 
 This exercise is designed to swap rETH to WETH on Uniswap V3.
 

--- a/courses/rocket-pool-reth-integration/2-understanding-reth/29-exercise-uniswap-v3-swap-reth-to-weth/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/29-exercise-uniswap-v3-swap-reth-to-weth/+page.md
@@ -1,6 +1,6 @@
 # `SwapUniswapV3.swapWethToReth` exercise
 
-Write your code inside the [`SwapUniswapV3` contract](../src/exercises/SwapUniswapV3.sol)
+Write your code inside the [`SwapUniswapV3` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/SwapUniswapV3.sol)
 
 This exercise is designed to swap WETH to rETH on Uniswap V3.
 

--- a/courses/rocket-pool-reth-integration/2-understanding-reth/31-exercise-balancer-swap-weth-to-reth/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/31-exercise-balancer-swap-weth-to-reth/+page.md
@@ -1,6 +1,6 @@
 # `SwapBalancerV2.swapWethToReth` exercise
 
-Write your code inside the [`SwapBalancerV2` contract](../src/exercises/SwapBalancerV2.sol)
+Write your code inside the [`SwapBalancerV2` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/SwapBalancerV2.sol)
 
 This exercise is designed to swap WETH to rETH on Balancer V2.
 

--- a/courses/rocket-pool-reth-integration/2-understanding-reth/33-exercise-balancer-swap-reth-to-weth/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/33-exercise-balancer-swap-reth-to-weth/+page.md
@@ -1,6 +1,6 @@
 # `SwapBalancerV2.swapRethToWeth` exercise
 
-Write your code inside the [`SwapBalancerV2` contract](../src/exercises/SwapBalancerV2.sol)
+Write your code inside the [`SwapBalancerV2` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/SwapBalancerV2.sol)
 
 This exercise is designed to swap rETH to WETH on Balancer V2.
 

--- a/courses/rocket-pool-reth-integration/3-aave-flash-leverage/11-exercise-get-max-flash-loan/+page.md
+++ b/courses/rocket-pool-reth-integration/3-aave-flash-leverage/11-exercise-get-max-flash-loan/+page.md
@@ -1,6 +1,6 @@
 # `FlashLev.getMaxFlashLoanAmountUsd` exercise
 
-Write your code inside the [`FlashLev` contract](../src/exercises/FlashLev.sol)
+Write your code inside the [`FlashLev` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/FlashLev.sol)
 
 This exercise is designed to test your understanding of the math for how the max flash loan amount is calculated.
 

--- a/courses/rocket-pool-reth-integration/3-aave-flash-leverage/13-exercise-open-leverage/+page.md
+++ b/courses/rocket-pool-reth-integration/3-aave-flash-leverage/13-exercise-open-leverage/+page.md
@@ -1,6 +1,6 @@
 # `FlashLev.open` exercise
 
-Write your code inside the [`FlashLev` contract](../src/exercises/FlashLev.sol).
+Write your code inside the [`FlashLev` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/FlashLev.sol).
 
 This exercise is designed to test your understanding of how to structure a smart contract function for initializing a leveraged position using a flash loan.
 

--- a/courses/rocket-pool-reth-integration/3-aave-flash-leverage/15-exercise-close-leverage/+page.md
+++ b/courses/rocket-pool-reth-integration/3-aave-flash-leverage/15-exercise-close-leverage/+page.md
@@ -1,6 +1,6 @@
 # `FlashLev.close` exercise
 
-Write your code inside the [`FlashLev` contract](../src/exercises/FlashLev.sol).
+Write your code inside the [`FlashLev` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/FlashLev.sol).
 
 This exercise is designed to test your understanding of how to structure a smart contract function for closing a leveraged position using a flash loan.
 

--- a/courses/rocket-pool-reth-integration/4-balancer-aura-liquidity/10-exercise-aura-add-liquidity/+page.md
+++ b/courses/rocket-pool-reth-integration/4-balancer-aura-liquidity/10-exercise-aura-add-liquidity/+page.md
@@ -1,6 +1,6 @@
 # `AuraLiquidity.deposit` exercise
 
-Write your code inside the [`AuraLiquidity` contract](../src/exercises/AuraLiquidity.sol)
+Write your code inside the [`AuraLiquidity` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/AuraLiquidity.sol)
 
 This exercise is design for you to gain experience adding liquidity to Aura.
 

--- a/courses/rocket-pool-reth-integration/4-balancer-aura-liquidity/12-exercise-aura-get-reward/+page.md
+++ b/courses/rocket-pool-reth-integration/4-balancer-aura-liquidity/12-exercise-aura-get-reward/+page.md
@@ -1,6 +1,6 @@
 # `AuraLiquidity.getReward` exercise
 
-Write your code inside the [`AuraLiquidity` contract](../src/exercises/AuraLiquidity.sol)
+Write your code inside the [`AuraLiquidity` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/AuraLiquidity.sol)
 
 This exercise is design for you to gain experience claiming rewards on Aura
 

--- a/courses/rocket-pool-reth-integration/4-balancer-aura-liquidity/14-exercise-aura-remove-liquidity/+page.md
+++ b/courses/rocket-pool-reth-integration/4-balancer-aura-liquidity/14-exercise-aura-remove-liquidity/+page.md
@@ -1,6 +1,6 @@
 # `AuraLiquidity.exit` exercise
 
-Write your code inside the [`AuraLiquidity` contract](../src/exercises/AuraLiquidity.sol)
+Write your code inside the [`AuraLiquidity` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/AuraLiquidity.sol)
 
 This exercise is design for you to gain experience removing liquidity from Aura.
 

--- a/courses/rocket-pool-reth-integration/4-balancer-aura-liquidity/6-exercise-balancer-add-liquidity/+page.md
+++ b/courses/rocket-pool-reth-integration/4-balancer-aura-liquidity/6-exercise-balancer-add-liquidity/+page.md
@@ -1,6 +1,6 @@
 # `BalancerLiquidity.join` exercise
 
-Write your code inside the [`BalancerLiquidity` contract](../src/exercises/BalancerLiquidity.sol)
+Write your code inside the [`BalancerLiquidity` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/BalancerLiquidity.sol)
 
 This exercise is design for you to gain experience adding liquidity to Balancer.
 

--- a/courses/rocket-pool-reth-integration/4-balancer-aura-liquidity/8-exercise-balancer-remove-liquidity/+page.md
+++ b/courses/rocket-pool-reth-integration/4-balancer-aura-liquidity/8-exercise-balancer-remove-liquidity/+page.md
@@ -1,6 +1,6 @@
 # `BalancerLiquidity.exit` exercise
 
-Write your code inside the [`BalancerLiquidity` contract](../src/exercises/BalancerLiquidity.sol)
+Write your code inside the [`BalancerLiquidity` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/BalancerLiquidity.sol)
 
 This exercise is design for you to gain experience removing liquidity from Balancer.
 

--- a/courses/rocket-pool-reth-integration/5-reth-nav/3-exercise-reth-nav/+page.md
+++ b/courses/rocket-pool-reth-integration/5-reth-nav/3-exercise-reth-nav/+page.md
@@ -1,6 +1,6 @@
 # `RethNav.getExchangeRate` exercise
 
-Write your code inside the [`RethNav` contract](../src/exercises/RethNav.sol)
+Write your code inside the [`RethNav` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/RethNav.sol)
 
 This exercise is design to implement a function that will calculate the exchange rate of 1 rETH into ETH.
 

--- a/courses/rocket-pool-reth-integration/6-eigenlayer-restake/10-exercise-eigen-layer-undelegate/+page.md
+++ b/courses/rocket-pool-reth-integration/6-eigenlayer-restake/10-exercise-eigen-layer-undelegate/+page.md
@@ -1,6 +1,6 @@
 # `EigenLayerRestake.undelegate` exercise
 
-Write your code inside the [`EigenLayerRestake` contract](../src/exercises/EigenLayerRestake.sol)
+Write your code inside the [`EigenLayerRestake` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/EigenLayerRestake.sol)
 
 This exercise is design to implement a function that will undelegate from the current operator.
 

--- a/courses/rocket-pool-reth-integration/6-eigenlayer-restake/12-exercise-eigen-layer-withdraw/+page.md
+++ b/courses/rocket-pool-reth-integration/6-eigenlayer-restake/12-exercise-eigen-layer-withdraw/+page.md
@@ -1,6 +1,6 @@
 # `EigenLayerRestake.withdraw` exercise
 
-Write your code inside the [`EigenLayerRestake` contract](../src/exercises/EigenLayerRestake.sol)
+Write your code inside the [`EigenLayerRestake` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/EigenLayerRestake.sol)
 
 This exercise is design to implement a function that will withdraw rETH from EigenLayer.
 

--- a/courses/rocket-pool-reth-integration/6-eigenlayer-restake/14-exercise-eigen-layer-claim-rewards/+page.md
+++ b/courses/rocket-pool-reth-integration/6-eigenlayer-restake/14-exercise-eigen-layer-claim-rewards/+page.md
@@ -1,6 +1,6 @@
 # `EigenLayerRestake.claimRewards` exercise
 
-Write your code inside the [`EigenLayerRestake` contract](../src/exercises/EigenLayerRestake.sol)
+Write your code inside the [`EigenLayerRestake` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/EigenLayerRestake.sol)
 
 This exercise is design to implement a function that will claim restaking rewards from EigenLayer.
 

--- a/courses/rocket-pool-reth-integration/6-eigenlayer-restake/6-exercise-eigen-layer-deposit/+page.md
+++ b/courses/rocket-pool-reth-integration/6-eigenlayer-restake/6-exercise-eigen-layer-deposit/+page.md
@@ -1,6 +1,6 @@
 # `EigenLayerRestake.deposit` exercise
 
-Write your code inside the [`EigenLayerRestake` contract](../src/exercises/EigenLayerRestake.sol)
+Write your code inside the [`EigenLayerRestake` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/EigenLayerRestake.sol)
 
 This exercise is design to implement a function that will deposit rETH into EigenLayer.
 

--- a/courses/rocket-pool-reth-integration/6-eigenlayer-restake/8-exercise-eigen-layer-delegate/+page.md
+++ b/courses/rocket-pool-reth-integration/6-eigenlayer-restake/8-exercise-eigen-layer-delegate/+page.md
@@ -1,6 +1,6 @@
 # `EigenLayerRestake.delegate` exercise
 
-Write your code inside the [`EigenLayerRestake` contract](../src/exercises/EigenLayerRestake.sol)
+Write your code inside the [`EigenLayerRestake` contract](https://github.com/Cyfrin/defi-reth/blob/main/foundry/src/exercises/EigenLayerRestake.sol)
 
 This exercise is design to implement a function that will delegate to an operator.
 


### PR DESCRIPTION
Example page : https://updraft.cyfrin.io/courses/rocket-pool-reth-integration/understanding-reth/exercise-eth-to-reth-exchange-rate

When clicking on the link, we get a 404 because it's not redirecting to github