### PR TITLE
Foundry Fundamentals, Section 1: Update foundryup-zksync installation instructions, and fix minor issues in written lesson

### DIFF
--- a/courses/foundry/1-foundry-simple-storage/26-anvil-zksync-updated/+page.md
+++ b/courses/foundry/1-foundry-simple-storage/26-anvil-zksync-updated/+page.md
@@ -1,16 +1,16 @@
 ## Anvil ZKSync Update
 
-In this lesson, we will learn how to deploy to a ZKSync local node. It's similar to Anvil but for ZKSync. We will cover the latest updates to ZKSync, which allow for deployment using just one command, without the need for extra installations. To take advantage of this simplified process, it's important to have the most up-to-date version of Foundry ZKSync.
+In this lesson, we will learn how to deploy to a ZKSync local node. It's similar to Anvil but for ZKSync. We will cover the latest updates to ZKSync, which allow for deployment using just one command, without the need for extra installations. To take advantage of this simplified process, it's important to have the most up-to-date version of Foundry-ZKSync.
 
 The reason we want to deploy our contracts to a ZKSync environment is to ensure that our contracts are running smoothly on ZKSync as well, rather than just in an Ethereum environment.
 
-Lets review the Foundry ZKSync repository. We need to make sure that we are using the most up-to-date version of Foundry ZKSync.
+Lets review the Foundry ZKSync repository. We need to make sure that we are using the most up-to-date version of Foundry-ZKSync.
 
-If you have an older version of Foundry ZKSync installed, you may need to reinstall Foundry up ZKSync in order for Anvil-ZKSync to be downloaded.
+If you have an older version of `foundryup-zksync` installed, you may need to reinstall it in order for Anvil-ZKSync to be downloaded.
 
 Run this command to install:
 ```bash
-curl -L https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/install-foundry.sh | bash
+curl -L https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/install-foundry-zksync | bash
 ```
 
 To start your locally running ZKSync node, you can run:


### PR DESCRIPTION
Command to install `foundryup-zksync` is 
```
curl -L https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/install-foundry-zksync | bash
```
Source:
https://foundry-book.zksync.io/getting-started/installation

If using the old command to install, it returns an error.