### PR TITLE
Introduction to Python and Vyper, Section 2: Minor fixes in written lesson, and remove wrong CLI commands in lesson demo'ed in Remix

### DIFF
--- a/courses/intro-python-vyper-smart-contract-development/2-remix-coffee/16-deploy-parameter/+page.md
+++ b/courses/intro-python-vyper-smart-contract-development/2-remix-coffee/16-deploy-parameter/+page.md
@@ -10,7 +10,7 @@ We are going to make the price feed a state variable, up at the top.
 
 Since our structs are the same as in the last lesson, the `AggregatorV3Interface` is a new type.  We can create a variable, a state variable, or a storage variable, called `price_feed` of type `AggregatorV3Interface`. 
 
-In our deploy function we can say `self.price_feed = AggregatorV3Interface()` at address.  We are hardcoding this address into the contract.
+In our deploy function, we can say `self.price_feed = AggregatorV3Interface()` at address.  We are hardcoding this address into the contract.
 
 We can add a comment saying that we are using the Sepolia testnet: 
 

--- a/courses/intro-python-vyper-smart-contract-development/2-remix-coffee/24-msg-sender/+page.md
+++ b/courses/intro-python-vyper-smart-contract-development/2-remix-coffee/24-msg-sender/+page.md
@@ -41,11 +41,3 @@ We can see this in action if we redeploy the contract and call the withdraw func
 If we call the withdraw function from the owner account, it will be successful. However, if we call the withdraw function from a different account, it will revert with the error message "Not the contract owner!".
 
 This is an example of how we can use the msg.sender to control access to our smart contract functions. It's a simple but powerful technique that can be used to secure our code.
-
-```bash
-truffle compile
-```
-
-```bash
-truffle migrate
-```

--- a/courses/intro-python-vyper-smart-contract-development/2-remix-coffee/24-msg-sender/+page.md
+++ b/courses/intro-python-vyper-smart-contract-development/2-remix-coffee/24-msg-sender/+page.md
@@ -20,7 +20,7 @@ We use the `msg.sender` built-in variable to set the owner of the contract to th
 Then, in the withdraw function, we use the `assert` statement to make sure that the msg.sender is equal to the owner.
 
 ```python
-external
+@external
 def withdraw():
     """Take the money out of the contract, that people sent via the fund function.
     How do we make sure only we can pull the money out?


### PR DESCRIPTION
In video 24, the demo is done in Remix, so the `truffle` commands are not relevant.
Also, Truffle Frameword had been deprecated in 2023...