### PR TITLE
Fix typos in documentation files

### DIFF
--- a/courses/foundry/4-smart-contract-lottery/38-forked-test-environment-and-dynamic-private-keys/+page.md
+++ b/courses/foundry/4-smart-contract-lottery/38-forked-test-environment-and-dynamic-private-keys/+page.md
@@ -28,7 +28,7 @@ import {AutomationCompatibleInterface} from "chainlink/src/v0.8/automation/inter
 /**
  * @title Raffle
  * @author EngrPips
- * @notice This contract if Particpating in a Raffle and standing the chance to win.
+ * @notice This contract if Participating in a Raffle and standing the chance to win.
  * @dev This contract heavily implements the chainlink VRF and Automation
  */
 // 0x9ddfaca8183c41ad55329bdeed9f6a8d53168b1b => VRFCoordinator

--- a/courses/rocket-pool-reth-integration/7-footnote/2-reth-arbitrage/+page.md
+++ b/courses/rocket-pool-reth-integration/7-footnote/2-reth-arbitrage/+page.md
@@ -18,4 +18,4 @@ The test passed and it was possible to pull off a hypothetical arbitrage opportu
 
 Here are some limitations to consider. This is currently a hypothetical arbitrage opportunity. In a real environment, gas costs might make this strategy unprofitable. Also, before executing this strategy, we have to make sure that the rETH contract has enough ETH in the contract.
 
-To recognize arbitrage oppurtunities, it is useful to be able to find tokens paired together that are similar where one of the tokens is yield bearing and the other is not. Then you also need to find an AMM where that yield bearing token is sold at a fixed price or some price range.
+To recognize arbitrage opportunities, it is useful to be able to find tokens paired together that are similar where one of the tokens is yield bearing and the other is not. Then you also need to find an AMM where that yield bearing token is sold at a fixed price or some price range.

--- a/courses/security/4-puppy-raffle/27-weak-randomness-case-study/+page.md
+++ b/courses/security/4-puppy-raffle/27-weak-randomness-case-study/+page.md
@@ -89,7 +89,7 @@ assert(bool(uint8(map_1[v1])) == bool(1));
 
 The first line is where the mint function is being called by the attacking contract.
 
-The second line is where an assertion is made that the minted NFT has the desired rare traits. If this assersion fails, the whole transaction is reverted.
+The second line is where an assertion is made that the minted NFT has the desired rare traits. If this assertion fails, the whole transaction is reverted.
 
 **Attacker Receives Rare NFT:**
 


### PR DESCRIPTION
This pull request fixes several typos in the documentation:

1. Fixed formatting in the Raffle contract @notice line
2. Corrected "oppurtunities" to "opportunities" in the rETH arbitrage documentation
3. Fixed "assersion" to "assertion" in the puppy raffle security documentation

These changes improve readability and professionalism of the documentation.