### PR TITLE
Rocket Pool rETH Integration, Section 2, Understanding rETH: Escape dollar-sign in written lesson's Markdown

### DIFF
--- a/courses/rocket-pool-reth-integration/2-understanding-reth/1-eth-staking/+page.md
+++ b/courses/rocket-pool-reth-integration/2-understanding-reth/1-eth-staking/+page.md
@@ -21,4 +21,4 @@ The first step is to stake the 32 ETH. Alice can send a transaction to a deposit
 
 The validator key is used by the validator to sign blocks and attest to transactions. Alice will need to take the validator key and include it inside the server that runs the validator software. This provides an overview of how ETH staking works.
 
-Now we can see that for Alice to become an ETH staker, she first needs 32 ETH. Assuming one ETH is $3,000, then 32 ETH is $96,000. Additionally, she needs the technical skills to run a validator and secure the validator keys, along with her withdrawal key.
+Now we can see that for Alice to become an ETH staker, she first needs 32 ETH. Assuming one ETH is \$3,000, then 32 ETH is \$96,000. Additionally, she needs the technical skills to run a validator and secure the validator keys, along with her withdrawal key.


### PR DESCRIPTION
Escape dollar-sign to display the `$` symbol correctly in written lesson.

Screenshot of https://updraft.cyfrin.io/courses/rocket-pool-reth-integration/understanding-reth/eth-staking?lesson_format=transcript
<img width="975" alt="Screenshot 2025-04-29 at 6 27 25 PM" src="https://github.com/user-attachments/assets/8304b002-d125-43da-9ca6-5970e0cf32f5" />
