### PR TITLE
replace broken link LICENSE in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 [license-shield]: https://img.shields.io/github/license/cyfrin/updraft.svg?style=for-the-badge
 
-[license-url]: https://github.com/cyfrin/updraft/blob/master/LICENSE.txt
+[license-url]: https://github.com/Cyfrin/Updraft/blob/main/LICENSE
 
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
 


### PR DESCRIPTION
Hey! replaced dead link 

https://github.com/cyfrin/updraft/blob/master/LICENSE.txt - old
https://github.com/Cyfrin/Updraft/blob/main/LICENSE - new