### PR TITLE
Update +page.md

### DIFF
--- a/courses/advanced-foundry/3-develop-defi-protocol/8-defi-mint-dsc/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/8-defi-mint-dsc/+page.md
@@ -188,7 +188,7 @@ import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/shared/inte
 If you haven't installed the `Chainlink` contract kit yet, let's do that now.
 
 ```bash
-forge install smartcontractkit/chainlink-brownie-contracts@0.6.1 --no-commit
+forge install smartcontractkit/chainlink-brownie-contracts@0.6.1
 ```
 
 And of course, we'll append this to our remappings within `foundry.toml`.


### PR DESCRIPTION
Flag --no-commit causes an error:
$ forge install smartcontractkit/chainlink-brownie-contracts@0.6.1 --no-commit error: unexpected argument '--no-commit' found

Not creating a commit is the default behavior now, otherwise you have to pass --commit: https://getfoundry.sh/forge/reference/forge-install/