### PR TITLE
Noir programming and ZK circuits, Section 1: Update figure URL

### DIFF
--- a/courses/noir-programming-and-zk-circuits/1-welcome-to-noir/5-course-naviagtion/+page.md
+++ b/courses/noir-programming-and-zk-circuits/1-welcome-to-noir/5-course-naviagtion/+page.md
@@ -37,7 +37,7 @@ The most crucial file within this repository is `README.md`. Think of it as your
     *   Rare skills article
     *   Artem Chystiakov's article
     *   Smart Contract Programmer's video
-    *   `https://www.researchgate.net/figure/Example-of-the-Tornado-Cash-1-ETH-pool-addresses-A-through-F-deposit-to-and-withdraw_fig1_357925531`
+    *   `https://www.researchgate.net/figure/Example-of-the-Tornado-Cash-1-ETH-pool-addresses-A-through-F-deposit-to-and-withdraw_fig1_357925591`
     *   Krishang's Tornado Cash Rebuilt Repo
     *   The Tornado Cash codebase
     *   Cat Mcgee's Private Peace Hackathon Project


### PR DESCRIPTION
The URL is https://www.researchgate.net/figure/Example-of-the-Tornado-Cash-1-ETH-pool-addresses-A-through-F-deposit-to-and-withdraw_fig1_357925591

When checking if the URL changes periodically, it is unlikely to. Not sure why the original URL does not work. The ResearchGate webpage has an "Embed figure" link (under the down caret symbol button next to "View publication") which uses the URL above.