### PR TITLE
Assembly and Formal Verification: Consistent format to technical words (calldata, opcode)

### DIFF
--- a/courses/formal-verification/1-horse-store/10-stack-memory-and-storage/+page.md
+++ b/courses/formal-verification/1-horse-store/10-stack-memory-and-storage/+page.md
@@ -22,7 +22,7 @@ The important distinctions to keep in mind when considering `memory` and `storag
 - Memory is temporary and data will be cleared when an operation completes.
 - Storage is persistent and data will remain accessible when an operation completes.
 
-In addition to these, accessing data in `storage` is _much_ more expensive than that of data in `memory`. This can be seen clearly when comparing the appropriate op codes at [**evm.codes**](https://www.evm.codes/?fork=shanghai) (we'll be referencing this a lot, you might want to book mark it!).
+In addition to these, accessing data in `storage` is _much_ more expensive than that of data in `memory`. This can be seen clearly when comparing the appropriate opcodes at [**evm.codes**](https://www.evm.codes/?fork=shanghai) (we'll be referencing this a lot, you might want to book mark it!).
 
 I'll draw your attention to the SSTORE and MSTORE
 
@@ -30,4 +30,4 @@ I'll draw your attention to the SSTORE and MSTORE
 
 We can see clearly to what extent I mean _"more expensive"_. The difference in gas when accessing data in `storage` is **massive.**
 
-In the next lesson, I'll introduce you to two more op codes you're likely to see quite often, `PUSH` and `ADD`.
+In the next lesson, I'll introduce you to two more opcodes you're likely to see quite often, `PUSH` and `ADD`.

--- a/courses/formal-verification/1-horse-store/11-push-and-add-opcode/+page.md
+++ b/courses/formal-verification/1-horse-store/11-push-and-add-opcode/+page.md
@@ -8,29 +8,29 @@ _Follow along with this video:_
 
 ### Understanding Stack Operations in Programming
 
-Let's look at a practical example of how the stack operates with two common op codes `PUSH1` and `ADD`.
+Let's look at a practical example of how the stack operates with two common opcodes `PUSH1` and `ADD`.
 
-To recap what we saw in a previous lesson, the `ADD` op code takes the top two items on the stack and returns the sum of these items - placing this sum on the top of the stack.
+To recap what we saw in a previous lesson, the `ADD` opcode takes the top two items on the stack and returns the sum of these items - placing this sum on the top of the stack.
 
 You may be asking **"How does data get added to the stack to begin with?"**. This is where `PUSH` comes in. By navigating to [**evm.codes**](https://www.evm.codes/?fork=shanghai) we can see that there is a different `PUSH` code, pending the byte size of the data we're adding to the stack!
 
 ### Understanding PUSH and ADD
 
-We'll start by considering how to add a 1 byte object to the stack, for this we'd use the `PUSH1` op code.
+We'll start by considering how to add a 1 byte object to the stack, for this we'd use the `PUSH1` opcode.
 
 ![push-and-add-opcodes-1](/formal-verification-1/11-push-and-add-opcodes/push-and-add-opcodes-1.png)
 
-If we were then to call the `ADD` op code, it's going to take the top 2 items on our stack, sum them and add this sum back to the top of our stack.
+If we were then to call the `ADD` opcode, it's going to take the top 2 items on our stack, sum them and add this sum back to the top of our stack.
 
 ![push-and-add-opcodes-2](/formal-verification-1/11-push-and-add-opcodes/push-and-add-opcodes-2.png)
 
-> **Remember:** Were there _three_ items in our stack, the `ADD` op code would only sum the top two items, the result would be pushed to the top of the stack, leaving the first item in our stack untouched.
+> **Remember:** Were there _three_ items in our stack, the `ADD` opcode would only sum the top two items, the result would be pushed to the top of the stack, leaving the first item in our stack untouched.
 
 ### Wrap Up
 
-Here we've seen an example of two very common op codes.
+Here we've seen an example of two very common opcodes.
 
 - PUSH - adds items to the stack
 - ADD - removes the top two items from the stack, and adds their sum to the top of the stack
 
-I encourage you to familiarize yourself with more of the stack input/outputs on evm.codes. In later lessons we'll look more closely at op codes such as MSTORE and SSTORE which remove things from the stack and write them to memory!
+I encourage you to familiarize yourself with more of the stack input/outputs on evm.codes. In later lessons we'll look more closely at opcodes such as MSTORE and SSTORE which remove things from the stack and write them to memory!

--- a/courses/formal-verification/1-horse-store/12-push-opcode/+page.md
+++ b/courses/formal-verification/1-horse-store/12-push-opcode/+page.md
@@ -24,7 +24,7 @@ We know now that when we call our `updateHorseNumber()` function, we're sending 
 
 Our next step is going to be finding the function selector in this data and routing it to the code that updates horses.
 
-I'll mention here, so you're aware moving forward, Huff is smart enough to infer `PUSH` op codes from the data being passed.
+I'll mention here, so you're aware moving forward, Huff is smart enough to infer `PUSH` opcodes from the data being passed.
 
 What this means is, in Huff, these two methods are effectively equal:
 

--- a/courses/formal-verification/1-horse-store/13-calldataload/+page.md
+++ b/courses/formal-verification/1-horse-store/13-calldataload/+page.md
@@ -8,15 +8,15 @@ _Follow along with this video:_
 
 ### Accessing our Call Data's Function Selector
 
-We're already starting to code using pure op codes, very exciting!
+We're already starting to code using pure opcodes, very exciting!
 
 Alright, eventually someone is going to send our contract some `calldata` and we need to determine what to do with it. We do this by deriving the `function selector` from the first 4 bytes of the `calldata` being sent.
 
-Fortunately we have an op code just for this purpose! `calldataload` will allow us to load our `calldata` onto the stack.
+Fortunately we have an opcode just for this purpose! `calldataload` will allow us to load our `calldata` onto the stack.
 
 ![calldataload-1](/formal-verification-1/13-calldataload/calldataload-1.png)
 
-So we can see the `calldataload` op code is going to take whatever is on top of our stack, and use it as the `bytes offset`. Since we want to capture our _whole_ function selector, we set this offset to 0 by using `PUSH0` as the operation prior to `calldataload`.
+So we can see the `calldataload` opcode is going to take whatever is on top of our stack, and use it as the `bytes offset`. Since we want to capture our _whole_ function selector, we set this offset to 0 by using `PUSH0` as the operation prior to `calldataload`.
 
 ### Keeping Track of the Stack
 
@@ -31,7 +31,7 @@ Something that I like to do is leverage comments in my code as a visual means to
 
 In this example, I keep track of my stack and what's in it through commenting an array next to these operations. By adding and removing items in this visual way, you won't need to remember the order your stack is in as you code.
 
-Our Huff contract utilizing the `calldataload` op code should look like this:
+Our Huff contract utilizing the `calldataload` opcode should look like this:
 
 ```js
 #define macro MAIN() = takes(0) returns(0) {
@@ -40,4 +40,4 @@ Our Huff contract utilizing the `calldataload` op code should look like this:
 }
 ```
 
-We can see that the `calldataload` op code removed the `PUSH0` and replaced the first item in our stack with the first 32 bytes of `calldata` our contract was sent!
+We can see that the `calldataload` opcode removed the `PUSH0` and replaced the first item in our stack with the first 32 bytes of `calldata` our contract was sent!

--- a/courses/formal-verification/1-horse-store/14-shr/+page.md
+++ b/courses/formal-verification/1-horse-store/14-shr/+page.md
@@ -16,18 +16,18 @@ Our ultimate goal is to access the `function selector` of the `calldata` sent to
 0xe026c0170000000000000000000000000000000000000000000000000000000000000001
 ```
 
-In order to achieve this, there's an op code we can use! 😲
+In order to achieve this, there's an opcode we can use! 😲
 
 In [**evm.codes**](https://www.evm.codes/?fork=shanghai) search for `shr`. This stands for `Shift Right` and is precisely the tool we need.
 
 ![shr-1](/formal-verification-1/14-shr/shr-1.png)
 
-In order to use this op code, we need 2 items on the stack
+In order to use this opcode, we need 2 items on the stack
 
 - shift: number of bits to shift to the right
 - value: 32 bytes to shift
 
-Let's look at a simpl example!
+Let's look at a simple example!
 
 Consider below:
 
@@ -36,7 +36,7 @@ Consider below:
 1 byte = 8 bits
 ```
 
-It's important to remember that the `shr` op code is how many _bits_ we're shifting to the right, _not bytes_.
+It's important to remember that the `shr` opcode is how many _bits_ we're shifting to the right, _not bytes_.
 
 This means we can rewrite our hex in binary to see it's bits representation. We can use the command `cast --to-base 0x0102 bin` to have the binary output for us.
 

--- a/courses/formal-verification/1-horse-store/15-evm-playground/+page.md
+++ b/courses/formal-verification/1-horse-store/15-evm-playground/+page.md
@@ -16,11 +16,11 @@ We'll consider again our original value `0x0102`. If we `shr` by 4 we expect a h
 
 Let's see how this works in the evm.codes playground!
 
-Recall what's required on our stack for our `shr` op code to function. `shr` takes `number of bits to shift` and the `32 bytes to shift`. These items need to be in our stack, in this order (top down). Our order of operations in the playground should look like this:
+Recall what's required on our stack for our `shr` opcode to function. `shr` takes `number of bits to shift` and the `32 bytes to shift`. These items need to be in our stack, in this order (top down). Our order of operations in the playground should look like this:
 
 ![evm-playground-1](/formal-verification-1/15-evm-playground/evm-playground-1.png)
 
-By clicking `Run` in the playground we can then step through each op code and see how it affects our **memory**, **stack**, **storage** and **return values**.
+By clicking `Run` in the playground we can then step through each opcode and see how it affects our **memory**, **stack**, **storage** and **return values**.
 
 Stepping through our first operation, we can see that 102 is added to our stack.
 
@@ -38,7 +38,7 @@ This is a hex value which we know we can convert using `cast --to-base 0x10 dec`
 
 ### A Note On calldataload
 
-It's important to note that `calldataload` will only place **32 bytes** on the stack. This means, in our previous `calldata` example, **_the last 8 digits of our call data will not be included_**
+It's important to note that `calldataload` will only place **32 bytes** on the stack. This means, in our previous `calldata` example, **_the last 8 digits of our calldata will not be included_**
 
 ```
 0xe026c0170000000000000000000000000000000000000000000000000000000000000001

--- a/courses/formal-verification/1-horse-store/16-shr-calldata/+page.md
+++ b/courses/formal-verification/1-horse-store/16-shr-calldata/+page.md
@@ -41,7 +41,7 @@ And our stack should look like this:
 
 ![shr-calldata-1](/formal-verification-1/16-shr-calldata/shr-calldata-1.png)
 
-Our final step to isolate the `function selector` from our received `call data` is going to be executing the `shr` operation, exciting!
+Our final step to isolate the `function selector` from our received `calldata` is going to be executing the `shr` operation, exciting!
 
 ```js
 #define macro MAIN() = takes(0) returns(0) {

--- a/courses/formal-verification/1-horse-store/17-opcodes-recap/+page.md
+++ b/courses/formal-verification/1-horse-store/17-opcodes-recap/+page.md
@@ -26,13 +26,13 @@ Most of the time we're manipulating data, it's going to be on the stack and we'l
 
 ### Op Codes
 
-We also learnt that the EVM is effectively comprised of `op codes` which denote the operations we want executed. [**evm.codes**](https://www.evm.codes/?fork=shanghai) has been incredibly useful for us in our learning about the specifics of each `op code`!
+We also learnt that the EVM is effectively comprised of `opcodes` which denote the operations we want executed. [**evm.codes**](https://www.evm.codes/?fork=shanghai) has been incredibly useful for us in our learning about the specifics of each `opcode`!
 
-When sending data to a smart contract, we introduced the concept of `calldata`. When Solidity compiles, through it's use op codes it's able to understand the provided `calldata`, and one of the first things it attempts to determine is **_"What am I supposed to do with this data?"_**. The EVM accomplishes this through referencing a `calldata's` `function selector` and a process called `function dispatching` in which case the rest of the `call data` is routed to the function associated with this `function selector`.
+When sending data to a smart contract, we introduced the concept of `calldata`. When Solidity compiles, through it's use opcodes it's able to understand the provided `calldata`, and one of the first things it attempts to determine is **_"What am I supposed to do with this data?"_**. The EVM accomplishes this through referencing a `calldata's` `function selector` and a process called `function dispatching` in which case the rest of the `calldata` is routed to the function associated with this `function selector`.
 
 ### Huff
 
-What's really exciting is we accomplished the above (sans dispatching, that's coming next!), using Huff and raw `op codes`.
+What's really exciting is we accomplished the above (sans dispatching, that's coming next!), using Huff and raw `opcodes`.
 
 ```js
 #define macro MAIN() = takes(0) returns(0){
@@ -53,8 +53,8 @@ We can check how the byte code of our contract is doing so far with `huffc src/h
 60058060093d393df35f3560e01c
 ```
 
-We were also introduced to the evm.codes playground, wherein we can experiment with byte code and op code inputs to walk through each operation being executed. In the screenshot below, I've included the runtime byte code and we can see that it is indeed exactly what we've coded in our Huff contract!
+We were also introduced to the evm.codes playground, wherein we can experiment with byte code and opcode inputs to walk through each operation being executed. In the screenshot below, I've included the runtime byte code and we can see that it is indeed exactly what we've coded in our Huff contract!
 
 ![opcodes-recap-1](/formal-verification-1/17-opcodes-recap/opcodes-recap-1.png)
 
-In the next lesson we'll try our luck at function dispatching and routing the `call data` to where it needs to be. Let's go!
+In the next lesson we'll try our luck at function dispatching and routing the `calldata` to where it needs to be. Let's go!

--- a/courses/formal-verification/1-horse-store/18-dispatching/+page.md
+++ b/courses/formal-verification/1-horse-store/18-dispatching/+page.md
@@ -8,7 +8,7 @@ _Follow along with this video:_
 
 ### Routing The Call
 
-We've done it! We have the function selector on our stack. Now we want to route the `call data` to the correct function. In Solidity, this is handled for us, but when we're programming in byte code we need to explicitly tell the EVM what's being done.
+We've done it! We have the function selector on our stack. Now we want to route the `calldata` to the correct function. In Solidity, this is handled for us, but when we're programming in byte code we need to explicitly tell the EVM what's being done.
 
 Alright, now that we have the function selector, we're going to proceed by doing a couple of comparisons and `jump` to the data associated with the selector.
 

--- a/courses/formal-verification/1-horse-store/19-opcode-eq/+page.md
+++ b/courses/formal-verification/1-horse-store/19-opcode-eq/+page.md
@@ -6,7 +6,7 @@ _Follow along with this video:_
 
 ---
 
-In this lesson we're going to take the next step in routing our `call data` to the appropriate function! Previously we'd isolated our function selector and we'd said:
+In this lesson we're going to take the next step in routing our `calldata` to the appropriate function! Previously we'd isolated our function selector and we'd said:
 
 ```
 If f_select == updateHorseNumber -> jump to that data in the contract
@@ -20,11 +20,11 @@ updateHorseNumber = 0xcdfead2e
 readNumberOfHorses = 0xe026c017
 ```
 
-These selectors can be determines by running `cast sig "updateHorseNumber(uint256)"` and `cast sig readNumberOfHorses()` respectfully. Once we have these signatures, there's an op code we can use to check equality, the `EQ` op code! Let's review how it works in [**evm.codes**](https://www.evm.codes/?fork=shanghai)
+These selectors can be determines by running `cast sig "updateHorseNumber(uint256)"` and `cast sig readNumberOfHorses()` respectfully. Once we have these signatures, there's an opcode we can use to check equality, the `EQ` opcode! Let's review how it works in [**evm.codes**](https://www.evm.codes/?fork=shanghai)
 
 ![opcode-eq-1](/formal-verification-1/19-opcode-eq/opcode-eq-1.png)
 
-As we can see, the `EQ` op code takes the top item on our stack and compares it to the next item in the stack. This op code will return `1` if the values compared are equal and `0` if they are not equal.
+As we can see, the `EQ` opcode takes the top item on our stack and compares it to the next item in the stack. This opcode will return `1` if the values compared are equal and `0` if they are not equal.
 
 Let's remind ourselves of our current contract state:
 

--- a/courses/formal-verification/1-horse-store/2-what-are-opcodes/+page.md
+++ b/courses/formal-verification/1-horse-store/2-what-are-opcodes/+page.md
@@ -6,7 +6,7 @@ _Follow along with this video:_
 
 ---
 
-In the previous lesson we got a glimpse of a contract's `bytecode`. When interacting with any smart contract, whether during its creation or subsequent transactions, there's an essential component at play—`call data`. It's the raw bytes or raw data that you're sending to the blockchain.
+In the previous lesson we got a glimpse of a contract's `bytecode`. When interacting with any smart contract, whether during its creation or subsequent transactions, there's an essential component at play—`calldata`. It's the raw bytes or raw data that you're sending to the blockchain.
 
 ### What Exactly Is Call Data?
 
@@ -20,19 +20,19 @@ Each byte, which corresponds to two hex characters, essentially represents an op
 
 As humans, we're not wired to effortlessly comprehend machine-code or binary. Manually instructing thousands of transistors is just not something we're good at. Because of this, we turn to higher-level programming languages like Solidity that are easier for humans to understand!
 
-However, it's crucial to remember that the EVM doesn't understand Solidity; it operates at the lowest level of code. It's a machine that needs explicit instructions to work with data, whether storing it, memorizing it, or stacking it. These instructions are the aforementioned op codes.
+However, it's crucial to remember that the EVM doesn't understand Solidity; it operates at the lowest level of code. It's a machine that needs explicit instructions to work with data, whether storing it, memorizing it, or stacking it. These instructions are the aforementioned opcodes.
 
 ### The Ethereum Virtual Machine
 
-The Ethereum Virtual Machine is, put simply, a state machine that emulates the computational environment of the Ethereum network on your own computer. When you hear about sending data to the blockchain or transacting Ethereum, picture the EVM diligently converting those tasks into smaller, machine-executable instructions—op codes.
+The Ethereum Virtual Machine is, put simply, a state machine that emulates the computational environment of the Ethereum network on your own computer. When you hear about sending data to the blockchain or transacting Ethereum, picture the EVM diligently converting those tasks into smaller, machine-executable instructions—opcodes.
 
-For example, if we're instructing our contract to store the number seven at a particular storage location, a specific sequence of op codes will facilitate that operation. It's this collection of op codes that embodies the EVM—a universally accepted set of commands that carry out predefined activities.
+For example, if we're instructing our contract to store the number seven at a particular storage location, a specific sequence of opcodes will facilitate that operation. It's this collection of opcodes that embodies the EVM—a universally accepted set of commands that carry out predefined activities.
 
 > _Don't stress too much about not grasping it straight away, it is complex stuff._
 
 ### Diving Into Code Examples
 
-To illustrate further, each pair of hex digits in the smart contract reflects a single opcode. But there are instances, such as when larger values are 'pushed' onto the stack, that the pattern alters a bit. Regardless, the crux is that these opcodes—whether signifying `PUSH1` or `MSTORE` (for memory storage)—orchestrate the execution of call data instructions.
+To illustrate further, each pair of hex digits in the smart contract reflects a single opcode. But there are instances, such as when larger values are 'pushed' onto the stack, that the pattern alters a bit. Regardless, the crux is that these opcodes—whether signifying `PUSH1` or `MSTORE` (for memory storage)—orchestrate the execution of calldata instructions.
 
 ### The Evolution of Opcodes
 

--- a/courses/formal-verification/1-horse-store/20-jump-and-jumpi/+page.md
+++ b/courses/formal-verification/1-horse-store/20-jump-and-jumpi/+page.md
@@ -6,9 +6,9 @@ _Follow along with this video:_
 
 ---
 
-Ok, we're making great progress in our efforts to code our Huff function dispatching! As of now, our stack should have the true/false returned value of our function selector comparison on it. We found this bool by executing the `EQ` op code and comparing our call data function selector with our known function selector.
+Ok, we're making great progress in our efforts to code our Huff function dispatching! As of now, our stack should have the true/false returned value of our function selector comparison on it. We found this bool by executing the `EQ` opcode and comparing our calldata function selector with our known function selector.
 
-Our next step will be routing this call to the correct `Program Counter` for that function. We'll do this using the `JUMP` or `JUMPI` op codes, lets look at what they do in [**evm.codes**](https://www.evm.codes/?fork=shanghai).
+Our next step will be routing this call to the correct `Program Counter` for that function. We'll do this using the `JUMP` or `JUMPI` opcodes, lets look at what they do in [**evm.codes**](https://www.evm.codes/?fork=shanghai).
 
 **JUMP** - alters the `Program Counter`, thus breaking the linear path of the execution to another point in the deployed code. It is used to implement functionalities like functions.
 
@@ -18,11 +18,11 @@ For our purposes, we're going to use `JUMPI` since we want to `JUMP` if our `fun
 
 ![jump-and-jumpi-1](/formal-verification-1/20-jump-and-jumpi/jump-and-jumpi-1.png)
 
-We can see that `JUMPI` takes two stack inputs. The first is a `counter`, which is the new `program counter` our code execution will continue from. In our example, this is our function location, this is where we want our `call data` to be processed. The second input simply determines whether or not the `program counter` should be adjusted. If this value is 0, the current `program counter` is incremented, if the value is _anything else_ - the program counter will be set to whatever our first input is.
+We can see that `JUMPI` takes two stack inputs. The first is a `counter`, which is the new `program counter` our code execution will continue from. In our example, this is our function location, this is where we want our `calldata` to be processed. The second input simply determines whether or not the `program counter` should be adjusted. If this value is 0, the current `program counter` is incremented, if the value is _anything else_ - the program counter will be set to whatever our first input is.
 
 **Program Counter** - The Program Counter (PC) encodes which instruction, stored in the code, should be next read by the EVM. The program counter is usually incremented by one byte, to point to the following instruction, with some exceptions. For instance, the PUSHx instruction is longer than a single byte, and causes the PC to skip their parameter. The JUMP instruction does not increase the PC's value, instead, it modifies the program counter to a position specified by the top of the stack. JUMPI does this as well, if its condition is true (a nonzero code value), otherwise, it increments the PC like other instructions. - [evm.codes](https://www.evm.codes/about)
 
-With a new understanding of our `JUMPI` op code and how `program counters` work, we next need to set up 2 things in our `HorseStore.huff` contract.
+With a new understanding of our `JUMPI` opcode and how `program counters` work, we next need to set up 2 things in our `HorseStore.huff` contract.
 
 - Create a macro which represents our updateHorseStore function logic
 - Define the `program counter` for this macro
@@ -74,7 +74,7 @@ Now, in our `MAIN` macro, Huff affords us a nice syntax to assign reference to t
 #define macro SET_NUMBER_OF_HORSES() = takes(0) returns(0){}
 ```
 
-In what we've added above, `updateJump` is pointing to the `program counter` of `SET_NUMBER_OF_HORSES()`. Now, our `JUMPI` op code is going to take our `SET_NUMBER_OF_HORSES()` program counter from the top of the stack, and the next value down. We'll _jump_ to the location of the given `program counter` if this second value is **anything other than 0**.
+In what we've added above, `updateJump` is pointing to the `program counter` of `SET_NUMBER_OF_HORSES()`. Now, our `JUMPI` opcode is going to take our `SET_NUMBER_OF_HORSES()` program counter from the top of the stack, and the next value down. We'll _jump_ to the location of the given `program counter` if this second value is **anything other than 0**.
 
 ```js
 #define macro MAIN() = takes(0) returns(0){
@@ -100,4 +100,4 @@ Once the `JUMPI` operation is executed, our stack is empty! Let's take a look at
 60108060093d393df35f3560e01c63cdfead2e1461000f575b
 ```
 
-Great work so far! Let's keep going, next op code we'll be working with is `JUMPDEST`
+Great work so far! Let's keep going, next opcode we'll be working with is `JUMPDEST`

--- a/courses/formal-verification/1-horse-store/21-jumpdest/+page.md
+++ b/courses/formal-verification/1-horse-store/21-jumpdest/+page.md
@@ -17,9 +17,9 @@ Paste the returned runtime bytecode into the evm.codes playground and let's step
 
 ![jumpdest-1](/formal-verification-1/21-jumpdest/jumpdest-1.png)
 
-By adding the runtime bytecode to the playground, we're presented with almost exactly what we wrote in Huff, converted to pure op codes. Something that's going to stand out is the `JUMPDEST` code. To understand this op code, let's take one step back.
+By adding the runtime bytecode to the playground, we're presented with almost exactly what we wrote in Huff, converted to pure opcodes. Something that's going to stand out is the `JUMPDEST` code. To understand this opcode, let's take one step back.
 
-In the previous lesson we'd set `updateJump` as a pointer to our program counter of `SET_NUMBER_OF_HORSES()`. This is only partially true. When a `JUMP` or `JUMPI` op code is executed, it requires a stack input of a `valid jump destination`. Huff's syntax allows us to define `updateJump` as a new `valid jump destination` before our `JUMPI` operation is executed.
+In the previous lesson we'd set `updateJump` as a pointer to our program counter of `SET_NUMBER_OF_HORSES()`. This is only partially true. When a `JUMP` or `JUMPI` opcode is executed, it requires a stack input of a `valid jump destination`. Huff's syntax allows us to define `updateJump` as a new `valid jump destination` before our `JUMPI` operation is executed.
 
 ```js
 updateJump: SET_NUMBER_OF_HORSES(); // sets the compiled location of the SET_NUMBER_OF_HORSES macro as a valid jump destination.
@@ -27,7 +27,7 @@ updateJump: SET_NUMBER_OF_HORSES(); // sets the compiled location of the SET_NUM
 
 So, looking again at our playground:
 
-- Op Codes 1-4 - isolating `function selector` from received `call data`
+- Op Codes 1-4 - isolating `function selector` from received `calldata`
 - PUSH4 - Pushes our known `function selector` to the stack
 - EQ - Compares our isolated `function selector` to our known selector and returns 0/1
 - PUSH2 - Adds our jump destination to the stack
@@ -39,6 +39,6 @@ So, looking again at our playground:
 Currently of course, nothing is going to happen after we jump to our new destination. We haven't added any logic to our macro yet. I encourage you to experiment in the playground before moving on.
 
 What's left on our stack after stepping through the code?
-What happens if we provide call data that doesn't start with our expected `function selector`?
+What happens if we provide calldata that doesn't start with our expected `function selector`?
 
 Answer these questions, and I'll see you in the next lesson!

--- a/courses/formal-verification/1-horse-store/22-dup1/+page.md
+++ b/courses/formal-verification/1-horse-store/22-dup1/+page.md
@@ -8,9 +8,9 @@ _Follow along with this video:_
 
 ### Duplicating Stack Items
 
-At this point, what we've written will handle call data which pertains to the updateHorseNumber function selector. We need to ask ourselves - _"How are we going to handle if a different selector is passed with our received `call data`?"_
+At this point, what we've written will handle calldata which pertains to the updateHorseNumber function selector. We need to ask ourselves - _"How are we going to handle if a different selector is passed with our received `calldata`?"_
 
-We could do another comparison, but if we haven't jumped anywhere, our stack is empty. We would have to again derive what the call data's function selector is from scratch, implementing another round of `calldataload` and `shr`. There may be a better way...
+We could do another comparison, but if we haven't jumped anywhere, our stack is empty. We would have to again derive what the calldata's function selector is from scratch, implementing another round of `calldataload` and `shr`. There may be a better way...
 
 ```js
 #define macro MAIN() = takes(0) returns(0){
@@ -30,11 +30,11 @@ We could do another comparison, but if we haven't jumped anywhere, our stack is 
 #define macro SET_NUMBER_OF_HORSES() = takes(0) returns(0){}
 ```
 
-An op code is available to us which will help us achieve a cleaner and more gas efficient path to our goal, `DUP1`
+An opcode is available to us which will help us achieve a cleaner and more gas efficient path to our goal, `DUP1`
 
 ![dup1-1](/formal-verification-1/22-dup1/dup1-1.png)
 
-`DUP1` simply takes the top item of the stack, copies it and adds both items back to the stack. By executing this op code directly after the first time we accessed the `call data`'s `function selector`, it would keep a copy of this selector for us to access, on the bottom of our stack. How does this look in our code?
+`DUP1` simply takes the top item of the stack, copies it and adds both items back to the stack. By executing this opcode directly after the first time we accessed the `calldata`'s `function selector`, it would keep a copy of this selector for us to access, on the bottom of our stack. How does this look in our code?
 
 ```js
 #define macro MAIN() = takes(0) returns(0){
@@ -57,6 +57,6 @@ An op code is available to us which will help us achieve a cleaner and more gas 
 #define macro SET_NUMBER_OF_HORSES() = takes(0) returns(0){}
 ```
 
-I've updated the comments in the code above to visualize how our duplicated `function selector` is carried through each step of execution. We see resultingly that, if we don't jump to `updateJump`, our stack still retains the `function selector` that was passed with the received `call data`.
+I've updated the comments in the code above to visualize how our duplicated `function selector` is carried through each step of execution. We see resultingly that, if we don't jump to `updateJump`, our stack still retains the `function selector` that was passed with the received `calldata`.
 
 Now that we have access to this function selector again, we're prepared to start handling calls to `readNumberOfHorses()`. Let's look at that in the next lesson!

--- a/courses/formal-verification/1-horse-store/23-read-number-of-horses/+page.md
+++ b/courses/formal-verification/1-horse-store/23-read-number-of-horses/+page.md
@@ -8,7 +8,7 @@ _Follow along with this video:_
 
 ### Function Dispatching to readNumberOfHorses
 
-Now that our `call data`'s `function selector` is available to us on the stack again, we can progress, just like before in our comparison to a known `function selector` and jumping to that `program counter`.
+Now that our `calldata`'s `function selector` is available to us on the stack again, we can progress, just like before in our comparison to a known `function selector` and jumping to that `program counter`.
 
 ```js
 #define macro MAIN() = takes(0) returns(0){
@@ -43,6 +43,6 @@ So, what's happening in the code above?
 
 Continuing from where our code had previously left off, we're performing the same operations as before though with our new `function selector`. We `PUSH` `0xe026c017` to the stack and compare it to our duplicated `function selector`. This time, if a match is found, we jump to the location of the new macro we created `GET_NUMBER_OF_HORSES()`.
 
-Notice how we didn't execute `DUP1` a second time. We've omitted it this time as we know we won't need to perform further checks. What's especially cool about this is you've just written a function dispatcher this is **_more gas efficient_** than Solidity's! Solidity's function dispatching process would have unnecessarily duplicated our `call data` bytecode a second time - wasting gas!
+Notice how we didn't execute `DUP1` a second time. We've omitted it this time as we know we won't need to perform further checks. What's especially cool about this is you've just written a function dispatcher this is **_more gas efficient_** than Solidity's! Solidity's function dispatching process would have unnecessarily duplicated our `calldata` bytecode a second time - wasting gas!
 
 In the next lesson, we'll look more closely at JUMPDEST in [**evm.codes**](https://www.evm.codes/?fork=shanghai).

--- a/courses/formal-verification/1-horse-store/24-testing-jumpdest/+page.md
+++ b/courses/formal-verification/1-horse-store/24-testing-jumpdest/+page.md
@@ -15,11 +15,11 @@ huffc src/horseStoreV1/HorseStore.huff --bin-runtime
 5f3560e01c8063cdfead2e1461001a5763e026c0171461001b575b5b
 ```
 
-Entering this bytecode into the evm.codes playground we should see our contract, broken down into it's individual op codes. Make note of the two distinct `JUMPDEST` codes at the bottom of the call list.
+Entering this bytecode into the evm.codes playground we should see our contract, broken down into it's individual opcodes. Make note of the two distinct `JUMPDEST` codes at the bottom of the call list.
 
 ![testing-jumpdest-1](/formal-verification-1/24-testing-jumpdest/testing-jumpdest-1.png)
 
-If we assure that the call data we're passing begins with the updateHorseNumber function selector, things should be business as usual, until reach our first `JUMPI` code.
+If we assure that the calldata we're passing begins with the updateHorseNumber function selector, things should be business as usual, until reach our first `JUMPI` code.
 
 ![testing-jumpdest-2](/formal-verification-1/24-testing-jumpdest/testing-jumpdest-2.png)
 
@@ -27,4 +27,4 @@ We can see our first `JUMPI` code pertains to one of the JUMPDEST codes at the b
 
 ![testing-jumpdest-3](/formal-verification-1/24-testing-jumpdest/testing-jumpdest-3.png)
 
-And that's exactly what happens! Great work! 🎉I encourage you to experiment further before moving forward, try placing different contracts into the evm.codes playground and investigating how their op codes function and interact. The more experience you have with these concepts the better!
+And that's exactly what happens! Great work! 🎉I encourage you to experiment further before moving forward, try placing different contracts into the evm.codes playground and investigating how their opcodes function and interact. The more experience you have with these concepts the better!

--- a/courses/formal-verification/1-horse-store/25-revert/+page.md
+++ b/courses/formal-verification/1-horse-store/25-revert/+page.md
@@ -10,13 +10,13 @@ _Follow along with this video:_
 
 Now that we've accounted for each of our contract's function in our function dispatcher, we're done, right? Not exactly. Our code won't just stop executing if no valid `JUMPDEST` is found, it'll continue to the next operation (which in our case happens to be a `JUMPDEST`).
 
-We could easily imagine a scenario where `call data` is sent to our contract, no `function selector` matches are found, and arbitrary code is executed when we don't intend!
+We could easily imagine a scenario where `calldata` is sent to our contract, no `function selector` matches are found, and arbitrary code is executed when we don't intend!
 
-We should protect against this by terminating the execution when no matches are found by our dispatcher. We can leverage the `REVERT` op code to do this.
+We should protect against this by terminating the execution when no matches are found by our dispatcher. We can leverage the `REVERT` opcode to do this.
 
 ![revert-1](/formal-verification-1/25-revert/revert-1.png)
 
-The revert op code takes two stack inputs, the **byte offset** and **byte size**. Both of these are used to return data from memory (like an error code) when the REVERT operation is executed. We haven't dealt with memory and have no errors so we won't worry about this, we'll simply pass 0s.
+The revert opcode takes two stack inputs, the **byte offset** and **byte size**. Both of these are used to return data from memory (like an error code) when the REVERT operation is executed. We haven't dealt with memory and have no errors so we won't worry about this, we'll simply pass 0s.
 
 Our Huff contract with REVERT implemented should look something like this.
 
@@ -53,7 +53,7 @@ Our Huff contract with REVERT implemented should look something like this.
 #define macro GET_NUMBER_OF_HORSES() = takes(0) returns(0){}
 ```
 
-Now, if we head back to the [**evm.codes playground**](https://www.evm.codes/playground) with our new runtime bytecode (`huffc src/horseStoreV1/HorseStore.huff --bin-runtime`), we can send some garbage `call data` and step through the operations to see how the contract responds.
+Now, if we head back to the [**evm.codes playground**](https://www.evm.codes/playground) with our new runtime bytecode (`huffc src/horseStoreV1/HorseStore.huff --bin-runtime`), we can send some garbage `calldata` and step through the operations to see how the contract responds.
 
 ![revert-2](/formal-verification-1/25-revert/revert-2.png)
 

--- a/courses/formal-verification/1-horse-store/26-huff-interfaces/+page.md
+++ b/courses/formal-verification/1-horse-store/26-huff-interfaces/+page.md
@@ -8,7 +8,7 @@ _Follow along with this video:_
 
 ### Cleaning Up Our Code
 
-Great! At this point we've written our very own function dispatcher, and when we start breaking down Solidity bytecode, later in the course, you'll see that Solidity is going through this exact same process (with a few extra op codes we'll explain).
+Great! At this point we've written our very own function dispatcher, and when we start breaking down Solidity bytecode, later in the course, you'll see that Solidity is going through this exact same process (with a few extra opcodes we'll explain).
 
 ```js
 #define macro MAIN() = takes(0) returns(0){

--- a/courses/formal-verification/1-horse-store/27-storage-refresher/+page.md
+++ b/courses/formal-verification/1-horse-store/27-storage-refresher/+page.md
@@ -23,8 +23,8 @@ So, in order to update storage, there are a few things we need to do.
 ```js
 #define macro SET_NUMBER_OF_HORSES() = takes(0) returns(0){
     // 1. Give numberOfHorses a storage slot
-    // 2. Get the value to store from call data
-    // 3. Execute the SSTORE op code
+    // 2. Get the value to store from calldata
+    // 3. Execute the SSTORE opcode
 }
 ```
 

--- a/courses/formal-verification/1-horse-store/28-sstore/+page.md
+++ b/courses/formal-verification/1-horse-store/28-sstore/+page.md
@@ -10,13 +10,13 @@ _Follow along with this video:_
 
 ```js
 #define macro SET_NUMBER_OF_HORSES() = takes(0) returns(0){
-    // 1. Get the value to store from call data
+    // 1. Get the value to store from calldata
     // 2. Give numberOfHorses a storage slot
-    // 3. Execute the SSTORE op code
+    // 3. Execute the SSTORE opcode
 }
 ```
 
-These are the steps, determined in our previous lesson, that we need to take in order to add the necessary logic to our Huff macro. For our first step, we're going to leverage the `SSTORE` op code.
+These are the steps, determined in our previous lesson, that we need to take in order to add the necessary logic to our Huff macro. For our first step, we're going to leverage the `SSTORE` opcode.
 
 ![sstore-1](/formal-verification-1/28-sstore/sstore-1.png)
 
@@ -25,6 +25,6 @@ The stack inputs required are a **key** and a **value**
 - **Key** - 32 byte key - this is **where** in storage our data will be saved
 - **Value** - 32 byte value - this is **what** will be saved at our key's location in storage
 
-Note as well that this op code doesn't have any stack outputs. Executing this operation will pop the top two items off our stack and return nothing to it.
+Note as well that this opcode doesn't have any stack outputs. Executing this operation will pop the top two items off our stack and return nothing to it.
 
-Now that we understand how the `SSTORE` op code functions, we'll employ it in our contract in the next lesson.
+Now that we understand how the `SSTORE` opcode functions, we'll employ it in our contract in the next lesson.

--- a/courses/formal-verification/1-horse-store/30-accessing-constant-variables/+page.md
+++ b/courses/formal-verification/1-horse-store/30-accessing-constant-variables/+page.md
@@ -16,13 +16,13 @@ Now, we're going to need to reference this storage slot in our `SET_NUMBER_OF_HO
 
 ```js
 #define macro SET_NUMBER_OF_HORSES() = takes(0) returns(0){
-    // 1. Get the value to store from call data
+    // 1. Get the value to store from calldata
     // 2. Give numberOfHorses a storage slot
     [NUMBER_OF_HORSES_STORAGE_SLOT]            // [0]
-    // 3. Execute the SSTORE op code
+    // 3. Execute the SSTORE opcode
 }
 ```
 
 The syntax above references our defined constant and pushes its value to the top of our stack. `NUMBER_OF_HORSES_STORAGE_SLOT` is assigned a value of 0, thus 0 is added to the top of our stack. With our storage slot constant defined, we're now going to need the value we're storing.
 
-In the next lesson, we'll dive into how to isolate the function parameters from the `call data` passed to our contract. See you there!
+In the next lesson, we'll dive into how to isolate the function parameters from the `calldata` passed to our contract. See you there!

--- a/courses/formal-verification/1-horse-store/31-accessing-function-parameters/+page.md
+++ b/courses/formal-verification/1-horse-store/31-accessing-function-parameters/+page.md
@@ -6,22 +6,22 @@ _Follow along with this video:_
 
 ---
 
-Great!  Our goal at this point is going to be deriving the parameters which have been passed to our function from the `call data` we've received.  Let's remind ourselves what our received `call data` looks like:
+Great!  Our goal at this point is going to be deriving the parameters which have been passed to our function from the `calldata` we've received.  Let's remind ourselves what our received `calldata` looks like:
 
 ```
 0xcdfead2e0000000000000000000000000000000000000000000000000000001
 ```
 
-In this `call data`, our function selector is represented by the first four bytes of the hex `0xe026c017`, the remaining digits of this hex string represent the data passed to our function. So, we need to determine two things:
+In this `calldata`, our function selector is represented by the first four bytes of the hex `0xe026c017`, the remaining digits of this hex string represent the data passed to our function. So, we need to determine two things:
 
-1. How do we access the call data we received from within our `SET_NUMBER_OF_HORSES()` macro?
-2. How do we isolate the function parameters from our `call data`?
+1. How do we access the calldata we received from within our `SET_NUMBER_OF_HORSES()` macro?
+2. How do we isolate the function parameters from our `calldata`?
 
-Fortunate, the answer to both of these is effectively the same! We're going to use our friend `calldataload`. As before, you might remember, `calldataload` takes a single stack input - the bytes offset. This is going to allow us to control which section of the `call data we're referencing. Let's look at this in code:
+Fortunate, the answer to both of these is effectively the same! We're going to use our friend `calldataload`. As before, you might remember, `calldataload` takes a single stack input - the bytes offset. This is going to allow us to control which section of the `calldata we're referencing. Let's look at this in code:
 
 ```js
 #define macro SET_NUMBER_OF_HORSES() = takes(0) returns(0){
-    // get the op code from call data
+    // get the opcode from calldata
     0x04                              // [4] - Pushing '4' to the stack to be used as our bytes offset
     calldataload                      // [value] - Takes bytes offset from the stack, adds calldata offset by bytes offset to the stack
     // Assign a storage slot
@@ -32,11 +32,11 @@ Fortunate, the answer to both of these is effectively the same! We're going to u
 }
 ```
 
-All that remains once our function parameters have been isolated and the storage slot determined is to actually store the value. As seen above, this is easily done by calling the `sstore` op code.
+All that remains once our function parameters have been isolated and the storage slot determined is to actually store the value. As seen above, this is easily done by calling the `sstore` opcode.
 
 <sstore img>
 
-The sstore op code takes 2 stack inputs, the storage slot key, and a value to store. These are ready for us on our stack.  
+The sstore opcode takes 2 stack inputs, the storage slot key, and a value to store. These are ready for us on our stack.  
 
 One important thing I'll mention, that you also see added to the code snippet above is the `stop` code I've added. We add this to explicitly tell our contract to stop executing at this point. If we didn't the code would continue running, line by line which at best is a waste of gas and at worst can execute arbitrary code in our protocol causing unpredictable effects!
 

--- a/courses/formal-verification/1-horse-store/32-testing-our-macro-in-evm-codes/+page.md
+++ b/courses/formal-verification/1-horse-store/32-testing-our-macro-in-evm-codes/+page.md
@@ -12,7 +12,7 @@ Remember how to get your contracts bytecode: `huffc src/HorseStoreV1/HorseStore.
 
 Paste the output into the playground's provided workspace and assure you've entered calldata which contains our valid function selector in the field to the bottom left. By stepping through each line of execution we can clearly trace what's happening with our function call.
 
-Here's an example of valid call data to set our number of horses to 7 and the call trace we can expect:
+Here's an example of valid calldata to set our number of horses to 7 and the call trace we can expect:
 
 ```
 0xcdfead2e0000000000000000000000000000000000000000000000000000000000000007
@@ -21,8 +21,8 @@ Here's an example of valid call data to set our number of horses to 7 and the ca
 ![testing-macro-evm-codes-1](/formal-verification-1/32-testing-macro-evm-codes/testing-macro-evm-codes-1.png)
 
 
-I want to draw you attention to the `stop` op code I've added near the end. This code is an imperative aspect of handling functions in Huff.
+I want to draw you attention to the `stop` opcode I've added near the end. This code is an imperative aspect of handling functions in Huff.
 
-Code doesn't know when you want it to start and stop, it'll keep running until the application runs out of code. The `stop` op code affords a developer the power to explicitly tell the EVM 'We're done here, this execution is complete. This will prevent our code from continuing to run subsequent operations after completion our function call!
+Code doesn't know when you want it to start and stop, it'll keep running until the application runs out of code. The `stop` opcode affords a developer the power to explicitly tell the EVM 'We're done here, this execution is complete. This will prevent our code from continuing to run subsequent operations after completion our function call!
 
 This is amazing! What you'll find when we decompile our Solidity version of Horse Store, is that what we've just built out in Huff is effectively what Solidity is doing for us under the hood. Great work! Let's look at how to add the logic of our `getNumberOfHorses` function.

--- a/courses/formal-verification/1-horse-store/33-sload-mstore-return/+page.md
+++ b/courses/formal-verification/1-horse-store/33-sload-mstore-return/+page.md
@@ -12,25 +12,25 @@ Having got this far the next steps we take should be pretty straight forward. Le
 2. Load the value of that slot into memory
 3. return
 
-There are 3 op codes we'll be working with do accomplish this. The first is `SLOAD`
+There are 3 opcodes we'll be working with do accomplish this. The first is `SLOAD`
 
 ![sload-mstore-return-1](/formal-verification-1/33-sload-mstore-return/sload-mstore-return-1.png)
 
-Our SLOAD op code takes a single stack input - our key which points to the location of the storage slot we want to load from. This is a very gas intensive operation, be mindful!
+Our SLOAD opcode takes a single stack input - our key which points to the location of the storage slot we want to load from. This is a very gas intensive operation, be mindful!
 
-The output we expect from this op code is of course - the value stored at that location. It adds this to the top of our stack.
+The output we expect from this opcode is of course - the value stored at that location. It adds this to the top of our stack.
 
-The other op code we'll be looking at, is the `return` op code.
+The other opcode we'll be looking at, is the `return` opcode.
 
 ![sload-mstore-return-2](/formal-verification-1/33-sload-mstore-return/sload-mstore-return-2.png)
 
 `return` functions very similarly to `stop` in that is halts execution of our code. The difference here is that `return` is going to return requested data when it's executed. We can see in the above screenshot that `return` takes 2 stack inputs that allow us to define what data we want returned `offset` and `size`.
 
-It's important to notes, however, that the `return` op code returns data from _memory_, not storage. As an extra step, we need to load our data into memory first. To do this we'll be leveraging the `mstore` op code.
+It's important to notes, however, that the `return` opcode returns data from _memory_, not storage. As an extra step, we need to load our data into memory first. To do this we'll be leveraging the `mstore` opcode.
 
 ![sload-mstore-return-3](/formal-verification-1/33-sload-mstore-return/sload-mstore-return-3.png)
 
-`mstore` functions just like `sstore`, which we used previously, except this op code is going to push to memory, no storage.
+`mstore` functions just like `sstore`, which we used previously, except this opcode is going to push to memory, no storage.
 
 We can recall that memory, can be considered effectively the same as storage, like a giant array, except memory is deleted after a transaction completes.
 

--- a/courses/formal-verification/1-horse-store/34-get-number-of-horses-macro/+page.md
+++ b/courses/formal-verification/1-horse-store/34-get-number-of-horses-macro/+page.md
@@ -17,7 +17,7 @@ So, let's add the necessary logic to our Huff contract.
 
 In the above, we reference the slot we'd assigned to that constant and load it from storage. In order to return this value, we must first add it to memory.
 
-Recall our stack inputs for the `mstore` op code which we'll be using to accomplish this, `offset` and `value`.  Offset, in this case, can be thought of like 'the index of memory', but it represents the bytes offset of the data we're intending to pull from memory.
+Recall our stack inputs for the `mstore` opcode which we'll be using to accomplish this, `offset` and `value`.  Offset, in this case, can be thought of like 'the index of memory', but it represents the bytes offset of the data we're intending to pull from memory.
 
 Because we don't have anything in memory, we can just `PUSH0` to our stack for this required input.
 
@@ -35,7 +35,7 @@ You'll notice that our stack is empty after executing our `mstore` operation.  T
 
 When working with lots of data, it can be troublesome to keep track of 'what's in the stack?', 'what's in memory?', 'what's in storage?'.  This is precisely why people choose to program in abstracted languages like Solidity.
 
-Alright, now that we have our data in memory - we need to return it, with the `return` op code.
+Alright, now that we have our data in memory - we need to return it, with the `return` opcode.
 
 `Return` takes an `offset` and a `size`. The `offset` is our 'index in memory`, 0x00 (0) in our case. And the size of our return data is going to be 0x20 (32 bytes).  Our macro should look like this now:
 

--- a/courses/formal-verification/1-horse-store/35-testing-in-evm-codes/+page.md
+++ b/courses/formal-verification/1-horse-store/35-testing-in-evm-codes/+page.md
@@ -16,17 +16,17 @@ Our runtime bytecode should look something like this now (it keeps growing, the 
 5f3560e01c8063cdfead2e1461001b578063e026c01714610022575b6004355f55005b5f545f5260205ff3
 ```
 
-Because we're performing a read-only operation (readNumberOfHorses) all that's required to be passed as `call data` is our function selector `0xe026c017`, remember you can us the command `cast sig "readNumberOfHorses()"` to derive this signature.
+Because we're performing a read-only operation (readNumberOfHorses) all that's required to be passed as `calldata` is our function selector `0xe026c017`, remember you can us the command `cast sig "readNumberOfHorses()"` to derive this signature.
 
-Click run and step through the execution of this function call. The first steps are the same as before, our function dispatcher will compare the passed function signature vs our application's _known_ function signatures to determine which logic to perform on the passed `call data`.
+Click run and step through the execution of this function call. The first steps are the same as before, our function dispatcher will compare the passed function signature vs our application's _known_ function signatures to determine which logic to perform on the passed `calldata`.
 
-> **Note:** Simply loading our new bytecode and calling our `readNumberOfHorses` function may be a little uneventful - remember to first send call data to **_set_** a number of horses!
+> **Note:** Simply loading our new bytecode and calling our `readNumberOfHorses` function may be a little uneventful - remember to first send calldata to **_set_** a number of horses!
 
 Your contract state should look something like this if you've stepped through the `updateNumberOfHorses` execution (using 7 as a passed parameter):
 
 ![testing-in-evm-codes1](/formal-verification-1/35-testing-in-evm-codes/testing-in-evm-codes1.png)
 
-Let's step through the execution further and see how things perform. Looking at the op codes added to our contract following our `readNumberOfHorses()` jump destination (`JUMPDEST`) we should see:
+Let's step through the execution further and see how things perform. Looking at the opcodes added to our contract following our `readNumberOfHorses()` jump destination (`JUMPDEST`) we should see:
 
 1. PUSH0 - pushes our desired storage slot to the top of the stack for reference - in our case 0
 2. SLOAD - loads data from the storage slot on the top of the stack

--- a/courses/formal-verification/1-horse-store/36-huff-&-opcodes-recap/+page.md
+++ b/courses/formal-verification/1-horse-store/36-huff-&-opcodes-recap/+page.md
@@ -12,14 +12,14 @@ Wooo! This is very exciting. You've just written your first smart contract in Hu
 
 We learnt that, no matter the language you're writing your smart contract in(Solidity, Huff, Vyper..) they all start with a `Function Dispatcher`
 
-A `function dispatcher` is a section of code which is responsible for checking the `function selectors` of passed `call data` and routing the call to the appropriate logic associate with the `function selector`.
+A `function dispatcher` is a section of code which is responsible for checking the `function selectors` of passed `calldata` and routing the call to the appropriate logic associate with the `function selector`.
 
 ### Op Codes
 
-In addition to working with `function dispatchers`, we learnt how to manage storage slots via Huff's `FREE_STORAGE_POINTER()`! We also learnt a variety of op codes and they're uses. We learnt:
+In addition to working with `function dispatchers`, we learnt how to manage storage slots via Huff's `FREE_STORAGE_POINTER()`! We also learnt a variety of opcodes and they're uses. We learnt:
 
 - PUSH# - Adds items to the stack with # being representative of the number of bytes being pushed.
-- CALLDATALOAD - loads received `call data` into the stack for reference.
+- CALLDATALOAD - loads received `calldata` into the stack for reference.
 - SSTORE - saves values to storage
 - SLOAD - loads into the stack, values from storage
 - MSTORE - add values to memory
@@ -29,6 +29,6 @@ In addition to working with `function dispatchers`, we learnt how to manage stor
 
 ### Wrap Up
 
-This is heavy stuff, but you're doing great. If you're feeling a little overwhelmed - now's a great time to take a break. If things aren't quite clicking, I encourage you to come back and tinker with things. Make changes to our Huff contract, experiment with how the different op codes interact with each other. Additionally, the [Huff Documentation](https://docs.huff.sh/) does a great job helping to understand the EVM and I encourage you to give it a read as supplemental learnings.
+This is heavy stuff, but you're doing great. If you're feeling a little overwhelmed - now's a great time to take a break. If things aren't quite clicking, I encourage you to come back and tinker with things. Make changes to our Huff contract, experiment with how the different opcodes interact with each other. Additionally, the [Huff Documentation](https://docs.huff.sh/) does a great job helping to understand the EVM and I encourage you to give it a read as supplemental learnings.
 
 In the next lessons we're going to be diving into how to write Foundry tests which are compatible with Huff, allowing us to do all of our Huff debugging in Foundry. Let's go!

--- a/courses/formal-verification/1-horse-store/37-differential-testing-base-test-V1/+page.md
+++ b/courses/formal-verification/1-horse-store/37-differential-testing-base-test-V1/+page.md
@@ -8,11 +8,11 @@ _Follow along with this video:_
 
 ### Where We're At
 
-Let's take a moment to consider where exactly we're at right now.  We've written our Huff contract, and we have our Solidity contract on which it was based. Looking at these two languages, it's clear to see we'd never want to write a whole contract op code by op code. It's incredibly tedious, sure you may be a little more gas efficient, but you're looking at 5x the effort to accomplish something a higher level language can achieve much more easily.
+Let's take a moment to consider where exactly we're at right now.  We've written our Huff contract, and we have our Solidity contract on which it was based. Looking at these two languages, it's clear to see we'd never want to write a whole contract opcode by opcode. It's incredibly tedious, sure you may be a little more gas efficient, but you're looking at 5x the effort to accomplish something a higher level language can achieve much more easily.
 
 ### Differential Testing
 
-If we did decide the write it Huff however, we should be certain that our code is doing the same as we'd expect in Solidity. There's a great way to examine the accuracy of our Huff implementation via the use of `Differential Tests/Differential Fuzzing`. Once we've done that we'll break down what's happening in the Solidity code, op code by op code.
+If we did decide the write it Huff however, we should be certain that our code is doing the same as we'd expect in Solidity. There's a great way to examine the accuracy of our Huff implementation via the use of `Differential Tests/Differential Fuzzing`. Once we've done that we'll break down what's happening in the Solidity code, opcode by opcode.
 
 We can start by creating a new folder within our project's `test` directory. Name it `V1` and create a file within named `Base_TestV1.t.sol`. This test file will actually house all the tests for *both* our Huff and Solidity implementations.
 We accomplish this by having our Huff and Solidity versions of our tests inherit Base_TestV1. This will assure that both versions of our tests are exactly the same.

--- a/courses/formal-verification/1-horse-store/39-foundry-opcode-debugger/+page.md
+++ b/courses/formal-verification/1-horse-store/39-foundry-opcode-debugger/+page.md
@@ -24,7 +24,7 @@ The trickiest part of the debugger could easily be navigation to the correct pie
 
 Utilize the commands along the bottom of the screen to navigate, you're looking for our `calldataload` or our `function selector` checks. These are clear indicators that we're looking at our contracts implementation.
 
-Foundry's debugger allows us to step through execution op code by op code very similarly to how the evm.codes playground works! We've seen this a few times before in our experiments learning about op codes, but I encourage you to play with this debugger until you're familiar with it. Trying things out is the best way to learn.
+Foundry's debugger allows us to step through execution opcode by opcode very similarly to how the evm.codes playground works! We've seen this a few times before in our experiments learning about opcodes, but I encourage you to play with this debugger until you're familiar with it. Trying things out is the best way to learn.
 
 With the read functionality tested, we can move on to the write functionality, the ability to set a number of horses through `SET_NUMBER_OF_HORSES()`. Putting things together, I'll remind you how our `Base_TestV1.t.sol` should look.
 
@@ -58,15 +58,15 @@ abstract contract Base_TestV1 is Test{
 
 Our test looks great! It's very simple, we're assigning 777 to a variable, updating the number of courses in horseStore, then our assert reads from the contract to verify that the updating number was in fact stored!
 
-Let's run `forge test --debug testWriteValue` and see how it looks in the debugger. Before hand, it's good to get an idea of what you're looking out for amidst all the debugger op codes so as not to get lost.
+Let's run `forge test --debug testWriteValue` and see how it looks in the debugger. Before hand, it's good to get an idea of what you're looking out for amidst all the debugger opcodes so as not to get lost.
 
 ```bash
 cast to-base 777 hex
 0x309
 ```
 
-With the above, we can see that 0x309 should be expected to pop up as we walk through the op code execution in our debugger, and indeed it does.
+With the above, we can see that 0x309 should be expected to pop up as we walk through the opcode execution in our debugger, and indeed it does.
 
 ![foundry-opcode-debugger1](/formal-verification-1/39-foundry-opcode-debugger/foundry-opcode-debugger1.png)
 
-I can't encourage you enough to practice and experiment with this debugger. Being able to read through op code executions will be an invaluable low level skill for those serious about a deep understanding of the EVM.
+I can't encourage you enough to practice and experiment with this debugger. Being able to read through opcode executions will be an invaluable low level skill for those serious about a deep understanding of the EVM.

--- a/courses/formal-verification/1-horse-store/4-function-dispatching/+page.md
+++ b/courses/formal-verification/1-horse-store/4-function-dispatching/+page.md
@@ -41,7 +41,7 @@ We're most interested in the `input` data.
 
 ## How Call Data Works
 
-At first glance this input data may seem like a "jumble of numbers". This input is called the **call data**, and it is crucial because it tells the smart contract what task to perform.
+At first glance this input data may seem like a "jumble of numbers". This input is called the **calldata**, and it is crucial because it tells the smart contract what task to perform.
 
 So, we're left with a few questions
 
@@ -56,9 +56,9 @@ _Where did this data come from?_
 
 For those who have taken the Foundry Advance course, you know what a function selector is (for those who haven't go do that [**HERE**](https://updraft.cyfrin.io/courses/advanced-foundry)!)
 
-In short, every function in Solidity has a **signature** - a unique identifier formed by hashing its name and input types. The first 4 bytes of the call data correspond to the function selector.
+In short, every function in Solidity has a **signature** - a unique identifier formed by hashing its name and input types. The first 4 bytes of the calldata correspond to the function selector.
 
-So when you call `updateNumberOfHorses`, Remix sends the selector `0xe026c017` at the start of the call data. This acts like an address, telling Solidity which specific function you want to call.
+So when you call `updateNumberOfHorses`, Remix sends the selector `0xe026c017` at the start of the calldata. This acts like an address, telling Solidity which specific function you want to call.
 
 You can confirm this function selector in Foundry with the command:
 
@@ -71,7 +71,7 @@ cast sig "updateHorseNumber(uint256)"
 
 Behind the scenes, Solidity has a **function dispatcher** that matches the selector to the intended function and routes the call accordingly. This dispatching is handled natively when the solidity is compiled.
 
-However, if writing in a lower-level language like Huff, you have to manually set up the dispatcher yourself to connect call data to functions. This gives more control but requires extra work.
+However, if writing in a lower-level language like Huff, you have to manually set up the dispatcher yourself to connect calldata to functions. This gives more control but requires extra work.
 
 ![function-dispatching-2](/formal-verification-1/4-function-dispatching/function-dispatching-2.png)
 
@@ -79,22 +79,22 @@ However, if writing in a lower-level language like Huff, you have to manually se
 
 In summary, here is the full process when calling a function:
 
-1. Your call data is sent to the smart contract
+1. Your calldata is sent to the smart contract
 2. Smart contract sees the function selector in the first 4 bytes
 3. Dispatcher uses selector to route call to correct function
-4. Function executes based on the call data
+4. Function executes based on the calldata
 
 So while calling functions may seem magical, there are underlying mechanisms that enable this to work.
 
 ## Huff vs Solidity
 
-The core concepts around call data and dispatching apply whether using Huff or Solidity. The key difference is Huff operates at a lower level so you manage more of these details directly.
+The core concepts around calldata and dispatching apply whether using Huff or Solidity. The key difference is Huff operates at a lower level so you manage more of these details directly.
 
 Remix and Solidity handle a lot of this complexity behind the scenes. But understanding what's happening underneath is valuable for any blockchain developer.
 
 ## Conclusion
 
-Through exploring call data, function selectors, and dispatching, the "magic" of interacting with smart contracts is demystified. These crucial pieces enable our function calls to execute properly.
+Through exploring calldata, function selectors, and dispatching, the "magic" of interacting with smart contracts is demystified. These crucial pieces enable our function calls to execute properly.
 
 While Remix and Solidity simplify things, seeing the lower-level mechanics gives deeper insight into blockchain development. This knowledge empowers you to build more advanced smart contract systems.
 

--- a/courses/formal-verification/1-horse-store/40-updating-tests-to-fuzz-tests/+page.md
+++ b/courses/formal-verification/1-horse-store/40-updating-tests-to-fuzz-tests/+page.md
@@ -71,8 +71,8 @@ Boom. All there is to it to convert this simple function into a fuzz test.
 
 ### Risks of Low Level Code
 
-Working with op codes is POWERFUL, but as cliche as it is - *with great power, comes great responsibility*. Breaking the functionality of code written in such a low level is very easy.
+Working with opcodes is POWERFUL, but as cliche as it is - *with great power, comes great responsibility*. Breaking the functionality of code written in such a low level is very easy.
 
-Any of our `PUSH` op codes, even if off by a single digit will cause things to likely fail, the precision of capturing the correct offset, or referencing the correct storage slots is paramount when writing in low level code.  Its for this reason that if you choose to write in something low level like Assembly or Huff, you should back up you logic with robust fuzz testing and even formal verification tests to assure your Huff implementation acts precisely how it should.
+Any of our `PUSH` opcodes, even if off by a single digit will cause things to likely fail, the precision of capturing the correct offset, or referencing the correct storage slots is paramount when writing in low level code.  Its for this reason that if you choose to write in something low level like Assembly or Huff, you should back up you logic with robust fuzz testing and even formal verification tests to assure your Huff implementation acts precisely how it should.
 
 Don't worry, we'll absolutely be going over formal verification later in the course 😉

--- a/courses/formal-verification/1-horse-store/41-intro-to-deconstructing-a-solidity-smart-contract/+page.md
+++ b/courses/formal-verification/1-horse-store/41-intro-to-deconstructing-a-solidity-smart-contract/+page.md
@@ -11,10 +11,10 @@ _Follow along with this video:_
 Wow, we've learnt a lot.
 
 - We wrote the HorseStore contract in Huff
-- We learnt about call data and where it comes from and how it's used
+- We learnt about calldata and where it comes from and how it's used
 - We also learnt how the EVM interprets the data being sent to it
 
-With our experience with Huff and op codes our next goal is going to be much more in reach. We're going to crack open our solidity contract and walk through it op code by op code to understand what it does and why's it does it.  If you'd like to see the op code breakdowns for Huff and Solidity, I've included breakdown references in the **[GitHub Repo](https://github.com/Cyfrin/1-horse-store-s23/tree/main/breakdowns)**
+With our experience with Huff and opcodes our next goal is going to be much more in reach. We're going to crack open our solidity contract and walk through it opcode by opcode to understand what it does and why's it does it.  If you'd like to see the opcode breakdowns for Huff and Solidity, I've included breakdown references in the **[GitHub Repo](https://github.com/Cyfrin/1-horse-store-s23/tree/main/breakdowns)**
 
 Let's remind ourselves what the Solidity version of this contract looks like:
 
@@ -37,6 +37,6 @@ contract HorseStore {
 
 This is the part of the course where we will literally be ripping through binary. It's going to be heavy, but it's also going to be a lot of fun.  When you're ripping apart the binary of a contract you should always be asking yourself *What is this doing?* and *Why is this here?* By the end of this you'll be a gas optimizing monster and you'll be able to critique compilers (though gas optimizoors dunking on compilers is a bit of a Twitter meme - don't go too hard haha).
 
-A lot of smart contract developers really want performant and efficient code - this power will only unlock for you when you've got through the assembly and gained a deeper understanding and familiarity with the op codes available.
+A lot of smart contract developers really want performant and efficient code - this power will only unlock for you when you've got through the assembly and gained a deeper understanding and familiarity with the opcodes available.
 
 Go get a coffee things are about to get intense!

--- a/courses/formal-verification/1-horse-store/42-solidity-opcodes-from-bytecode/+page.md
+++ b/courses/formal-verification/1-horse-store/42-solidity-opcodes-from-bytecode/+page.md
@@ -8,21 +8,21 @@ _Follow along with this video:_
 
 ### Breaking Down Solidity
 
-In this lesson we're going to breakdown Solidity into it's component bytecode and directly compare the op codes in Solidity with those of Huff.
+In this lesson we're going to breakdown Solidity into it's component bytecode and directly compare the opcodes in Solidity with those of Huff.
 
-Start by creating a new folder named `breakdowns`, we'll be compiling our op code breakdowns in here.
+Start by creating a new folder named `breakdowns`, we'll be compiling our opcode breakdowns in here.
 
-Navigate to `out/horseStoreV1/HorseStore.sol/HorseStore.json`. This is the ABI of our deployed HorseStore contract. Within this file you'll find a `bytecode` object with an `object` property. This represents our op codes for the contract in bytecode!
+Navigate to `out/horseStoreV1/HorseStore.sol/HorseStore.json`. This is the ABI of our deployed HorseStore contract. Within this file you'll find a `bytecode` object with an `object` property. This represents our opcodes for the contract in bytecode!
 
 ![solidity-opcodes-from-bytecode1](/formal-verification-1/42-solidity-opcodes-from-bytecode/solidity-opcodes-from-bytecode1.png)
 
 Create a new file named `solc-breakdowns.c++`. This won't actually be a C++ file, but some of the syntax highlighting for C++ will make things easier on us. You can paste your bytecode to the top of this file as a comment for reference.
 
-As we know, every 2 digits in this bytecode represents an op code. For example, the very first pair `60` is `PUSH1`. We could absolutely go through the bytecode, pair by pair and break things down that way.
+As we know, every 2 digits in this bytecode represents an opcode. For example, the very first pair `60` is `PUSH1`. We could absolutely go through the bytecode, pair by pair and break things down that way.
 
 But that's a lot of work.
 
-Let's take our bytecode and paste it into the **[evm.codes playground](https://www.evm.codes/playground)**. By switching the left panel to `mneumonic` via the drop down we'll be given a list of the op codes for this contract! It should look something like this:
+Let's take our bytecode and paste it into the **[evm.codes playground](https://www.evm.codes/playground)**. By switching the left panel to `mneumonic` via the drop down we'll be given a list of the opcodes for this contract! It should look something like this:
 
 <details>
 <Summary> Op Codes </summary>

--- a/courses/formal-verification/1-horse-store/43-soliditys-free-memory-pointer/+page.md
+++ b/courses/formal-verification/1-horse-store/43-soliditys-free-memory-pointer/+page.md
@@ -8,7 +8,7 @@ _Follow along with this video:_
 
 ### Starting the Op Code Breakdown
 
-Let's start breaking down what all the op codes in our `solc-breakdowns.c++` file do.
+Let's start breaking down what all the opcodes in our `solc-breakdowns.c++` file do.
 
 I'll update this reference as we go through each section of bytecode:
 
@@ -164,7 +164,7 @@ PUSH1 0x40
 MSTORE
 ```
 
-This section of bytecode is going to be seen in almost every contract you work with and represents the first part of the `Contract Creation Code`. Any time we send a transaction on chain, the entry point of our transaction will be the first couple op codes.
+This section of bytecode is going to be seen in almost every contract you work with and represents the first part of the `Contract Creation Code`. Any time we send a transaction on chain, the entry point of our transaction will be the first couple opcodes.
 
 ```
 PUSH1 0x80
@@ -172,7 +172,7 @@ PUSH1 0x40
 MSTORE
 ```
 
-These op codes represent Solidity's `Free Memory Pointer`. Their execution, in order will:
+These opcodes represent Solidity's `Free Memory Pointer`. Their execution, in order will:
 
 1. Push 0x80 to the stack
 2. Push 0x40 to the stack
@@ -182,7 +182,7 @@ Previously I'd described memory as an array with slots demarked with indexes. Th
 
 A part of memory management is keeping track of where in this memory "array" we have free memory available (to avoid overwriting previously stored data!). This is where the `free memory pointer` comes in.
 
-What these op codes are doing, is making a note of where our free memory is located, at 0x40. The idea being that every time we want to write to memory, we'll do 3 things:
+What these opcodes are doing, is making a note of where our free memory is located, at 0x40. The idea being that every time we want to write to memory, we'll do 3 things:
 
 1. Check the value stored at 0x40 to determine where free memory is available
 2. write our data to the free memory location
@@ -190,4 +190,4 @@ What these op codes are doing, is making a note of where our free memory is loca
 
 In Solidity `0x40` is special and exists as this `free memory pointer`. Not all languages share this feature however, Vyper and Huff being notable examples of not having a `free memory pointer`
 
-As we walk through the solidity op codes, we'll see the free memory pointer being referenced and updated many times. We'll become very familiar with it's use!
+As we walk through the solidity opcodes, we'll see the free memory pointer being referenced and updated many times. We'll become very familiar with it's use!

--- a/courses/formal-verification/1-horse-store/44-msg.value-check/+page.md
+++ b/courses/formal-verification/1-horse-store/44-msg.value-check/+page.md
@@ -144,7 +144,7 @@ _Follow along with this video:_
 
 ### Non-Payable Constructor Check
 
-When going through op codes, I like to repeatedly ask myself _What does this chunk do?_. Let's look at the next check and walk through is execution.
+When going through opcodes, I like to repeatedly ask myself _What does this chunk do?_. Let's look at the next check and walk through is execution.
 
 I'll typically look out for 'break points', things like `Revert` and `Return` to determine where a "chunk" starts and stops.
 
@@ -159,9 +159,9 @@ DUP1         // [0, 0, msg.value]
 REVERT       // [msg.value]
 ```
 
-I've added our comment notation to our op code list to keep track of what's on our stack. So, what's happening here?
+I've added our comment notation to our opcode list to keep track of what's on our stack. So, what's happening here?
 
-We've seen many of these op codes before, but some of them are new. Each time a new op code is mentioned, I'll include a screenshot of it's details from [evm.codes](https://www.evm.codes/#34?fork=cancun). I encourage you to use this website like a dictionary as we attempt to define what's being executed. `CALLVALUE` adds to the stack, the value included with the current call.
+We've seen many of these opcodes before, but some of them are new. Each time a new opcode is mentioned, I'll include a screenshot of it's details from [evm.codes](https://www.evm.codes/#34?fork=cancun). I encourage you to use this website like a dictionary as we attempt to define what's being executed. `CALLVALUE` adds to the stack, the value included with the current call.
 
 ![msg_value-check1](/formal-verification-1/44-msg.value-check/msg_value-check1.png)
 

--- a/courses/formal-verification/1-horse-store/45-CODECOPY/+page.md
+++ b/courses/formal-verification/1-horse-store/45-CODECOPY/+page.md
@@ -161,7 +161,7 @@ RETURN
 INVALID
 ```
 
-The first several op codes are examples of things we've seen before. Without getting into the specifics of what the data being added to the stack is, we can easily follow along with how the stack is being manipulated.
+The first several opcodes are examples of things we've seen before. Without getting into the specifics of what the data being added to the stack is, we can easily follow along with how the stack is being manipulated.
 
 This continues until we reach the `CODECOPY` operation. We'd mentioned it briefly before, but now we're going to see it in action. Let see what it does.
 
@@ -179,9 +179,9 @@ cast to-base 0x001b dec
 27
 ```
 
-This is literally saying 'start my copy at the 27th op code of the code being copied'.
+This is literally saying 'start my copy at the 27th opcode of the code being copied'.
 
-I can tell you from experience - this is where our `runtime` bytecode begins and it is omitting the `creation code` seen at the start of our deployment! The copy will begin immediately after the `INVALID` op code coming up.
+I can tell you from experience - this is where our `runtime` bytecode begins and it is omitting the `creation code` seen at the start of our deployment! The copy will begin immediately after the `INVALID` opcode coming up.
 
 - `size`: byte size to copy - how much of the code to copy into memory. The value in our stack is 0xa5.
 
@@ -190,7 +190,7 @@ cast to-base 0xa5 dec
 165
 ```
 
-What we're passing turns out to bed 165 bytes of data, which represents the rest of our contract. Once that's copied into memory we can continue along with our next op codes...
+What we're passing turns out to bed 165 bytes of data, which represents the rest of our contract. Once that's copied into memory we can continue along with our next opcodes...
 
 ```
 JUMPDEST      // [msg.value]
@@ -211,7 +211,7 @@ After copying our `runtime code` to memory we `PUSH0` and call `RETURN`.
 
 `RETURN` takes a bytes offset and a size to be returned from memory. We're passing `0x00` and `0xa5` which represents the whole size of the `runtime code` we've copied into memory. This is what our transaction is returning and is being copied to the blockchain!
 
-The astute among you may be asking - **_What about the `CREATE` and `CREATE2` op codes? Shouldn't they be called to save a contract on chain?_** - The short answer is, there are a few ways to save a contract to the blockchain.
+The astute among you may be asking - **_What about the `CREATE` and `CREATE2` opcodes? Shouldn't they be called to save a contract on chain?_** - The short answer is, there are a few ways to save a contract to the blockchain.
 
 `CREATE`/`CREATE2` are used by contracts to create other contracts. Another way to create a contract on chain is by passing `nil` in the `to` field of a transaction, which is what's done through the `RETURN` method we're leveraging here.
 

--- a/courses/formal-verification/1-horse-store/46-a-note-on-your-new-powers/+page.md
+++ b/courses/formal-verification/1-horse-store/46-a-note-on-your-new-powers/+page.md
@@ -41,4 +41,4 @@ constructor() payable {}
 
 >**Note:** Just because it saves gas, doesn't mean it's the best choice. The msg.value check brings some valuable security functionality such as not accidentally locking a bunch of funds on contract creation. Consider your optimizations carefully!
 
-There are all sorts of optimizations that will spring to mind the more familiar you become with the deeper workings of the EVM and op codes. In the next lesson we'll introduce `runtime code` in more detail!
+There are all sorts of optimizations that will spring to mind the more familiar you become with the deeper workings of the EVM and opcodes. In the next lesson we'll introduce `runtime code` in more detail!

--- a/courses/formal-verification/1-horse-store/47-runtime-code-introduction/+page.md
+++ b/courses/formal-verification/1-horse-store/47-runtime-code-introduction/+page.md
@@ -8,7 +8,7 @@ _Follow along with this video:_
 
 ### Runtime Code
 
-With `contract creation` understood, we move onto the runtime section of our op codes. Remember, Solidity conveniently will break each of theses sections up by adding an `INVALID` op code between them.
+With `contract creation` understood, we move onto the runtime section of our opcodes. Remember, Solidity conveniently will break each of theses sections up by adding an `INVALID` opcode between them.
 
 <details>
 <Summary> Op Codes </summary>
@@ -181,6 +181,6 @@ What's happening above?
 
 The first three codes are Solidity's `free memory pointer` again! We'll get used to seeing this. From there we see another chunk we've seen before - the msg.value check.
 
-The Solidity compiler is smart enough to check all the functions within a contract and determine if any of them are payable. If none of a contract's functions are payable, any call data sent to the contract's runtime code will be checked for value and the transaction will revert if any is found!
+The Solidity compiler is smart enough to check all the functions within a contract and determine if any of them are payable. If none of a contract's functions are payable, any calldata sent to the contract's runtime code will be checked for value and the transaction will revert if any is found!
 
 We'll continue from the `JUMPDEST` in the next lesson to see how a call is handled when `msg.value == 0`.

--- a/courses/formal-verification/1-horse-store/48-function-selector-size-check/+page.md
+++ b/courses/formal-verification/1-horse-store/48-function-selector-size-check/+page.md
@@ -160,25 +160,25 @@ CALLDATASIZE   // [calldata_size, 0x04]
 LT             //
 ```
 
-Continuing from our `JUMPDEST` (this is if `msg.value == 0`), we are then clearing our stack with `POP`. Next we push `0x04` to our stack with `PUSH1`, we'll see why soon. Then we execute an op code we haven't seen before. `CALLDATASIZE`.
+Continuing from our `JUMPDEST` (this is if `msg.value == 0`), we are then clearing our stack with `POP`. Next we push `0x04` to our stack with `PUSH1`, we'll see why soon. Then we execute an opcode we haven't seen before. `CALLDATASIZE`.
 
 ![function-selector-size-check1](/formal-verification-1/48-function-selector-size-check/function-selector-size-check1.png)
 
-We can see that this op code takes no stack input, but the stack output is the `byte size of the call data`. A couple examples:
+We can see that this opcode takes no stack input, but the stack output is the `byte size of the calldata`. A couple examples:
 
-If call data = 0x04
+If calldata = 0x04
 
 - CALLDATASIZE = 0x01
 
-if call data = 0x05284a06
+if calldata = 0x05284a06
 
 - CALLDATASIZE = 0x04
 
-We then hit another new op code `LT` this stands for `less than`.
+We then hit another new opcode `LT` this stands for `less than`.
 
 ![function-selector-size-check2](/formal-verification-1/48-function-selector-size-check/function-selector-size-check2.png)
 
-The LT op code will return 1 if the top item of the stack is less than the second from top item in the stack. Functionally this is checking the the call data being received is long enough to satisfy the required length of a contracts function selector (4 bytes).
+The LT opcode will return 1 if the top item of the stack is less than the second from top item in the stack. Functionally this is checking the the calldata being received is long enough to satisfy the required length of a contracts function selector (4 bytes).
 
 ```js
 JUMPDEST       // [msg.value]
@@ -224,6 +224,6 @@ REVERT            // []
 
 The summarize all this, we're checking our `CALLDATASIZE`, if it is less than the size of a `function selector` we are jumping our execution to the `0x30` offset and reverting the transaction.
 
-The Solidity compiler again is smart enough to know if a contract possesses a `fallback` function and how to handle `call data` that can't be processed by a contract's functions by reverting the call when the `call data` passed is less then 4 bytes long.
+The Solidity compiler again is smart enough to know if a contract possesses a `fallback` function and how to handle `calldata` that can't be processed by a contract's functions by reverting the call when the `calldata` passed is less then 4 bytes long.
 
-In the next lesson we'll see how `call data` is handled when it passes this `CALLDATASIZE` check!
+In the next lesson we'll see how `calldata` is handled when it passes this `CALLDATASIZE` check!

--- a/courses/formal-verification/1-horse-store/49-soliditys-function-dispatcher/+page.md
+++ b/courses/formal-verification/1-horse-store/49-soliditys-function-dispatcher/+page.md
@@ -8,7 +8,7 @@ _Follow along with this video:_
 
 ### Solidity's Function Dispatcher
 
-The next chunk of op codes we come across is going to represent Solidity's `function dispatcher`. Let's go through how it works together. As always, here's a reference of the op codes we've covered so far and where we are in the execution:
+The next chunk of opcodes we come across is going to represent Solidity's `function dispatcher`. Let's go through how it works together. As always, here's a reference of the opcodes we've covered so far and where we are in the execution:
 
 <details>
 <Summary> Op Codes </summary>
@@ -164,9 +164,9 @@ PUSH1 0x34        // [0x34, 0xcdfead2e == func_selector, func_selector]
 JUMPI             // [func_selector]
 ```
 
-So what's this doing?  We're pushing `0x00` to the stack and executing `CALLDATALOAD`, we've seen this one before. It takes a bytes offset from the top of our stack (`0x00`) and adds to our stack 32 Bytes of call data beginning at the offset.
+So what's this doing?  We're pushing `0x00` to the stack and executing `CALLDATALOAD`, we've seen this one before. It takes a bytes offset from the top of our stack (`0x00`) and adds to our stack 32 Bytes of calldata beginning at the offset.
 
-We next execute a right shift with `SHR`. If we recall, it takes an amount to shift and the data to be shifted. `cast to-base 0xe0 dec` will tell us we're shifting our `CALLDATA_32BYTES` 224 bits (28 Bytes) to the right. This is going to leave the first 4 bytes of our `call data`, on the stack - our `function selector`.
+We next execute a right shift with `SHR`. If we recall, it takes an amount to shift and the data to be shifted. `cast to-base 0xe0 dec` will tell us we're shifting our `CALLDATA_32BYTES` 224 bits (28 Bytes) to the right. This is going to leave the first 4 bytes of our `calldata`, on the stack - our `function selector`.
 
 What remains will look something like this:
 ```
@@ -186,7 +186,7 @@ PUSH1 0x34        // [0x34, 0xcdfead2e == func_selector, func_selector]
 JUMPI             // [func_selector]
 // if func_selector == 0xcdfead2e jump to set_number_of_horses
 ```
-We're pushing  our known function selector to the stack (this is our `updateNumberOfHorses()` function!), and then comparing it to the `call data` `function selector` to see if there's a match.
+We're pushing  our known function selector to the stack (this is our `updateNumberOfHorses()` function!), and then comparing it to the `calldata` `function selector` to see if there's a match.
 
 We then push a program counter/`JUMPDEST` to the stack and execute `JUMPI`, jumping to that function's logic if `0xcdfead2e == func_selector`.
 
@@ -207,11 +207,11 @@ JUMPI             // [func_selector]
 
 Basically the same process is being followed for the second function of our Solidity contract.
 
-- Duplicate the `function selector` from `call data`
+- Duplicate the `function selector` from `calldata`
 - Push our known `function selector` (0xe026c017 `readNumberOfHorses()`)
 - Use `EQ` to determine if they are equal
 - Push a program counter/`JUMPDEST` to the stack
-- `JUMPI` to the `JUMPDEST` if the `call data` function selector and the known `function selector` are equal.
+- `JUMPI` to the `JUMPDEST` if the `calldata` function selector and the known `function selector` are equal.
 
 Something to note here - In the `function dispatcher` we wrote in Huff, we recognized that our second check wouldn't require duplicating the `func_selector` again. Solidity however *does* still perform this duplication! This is a potential gas optimization we've found already!
 
@@ -225,4 +225,4 @@ REVERT
 
 This will prevent calls to our contract from executing arbitrary code if a `function selector` match isn't found.
 
-We're already through over half the op codes of our contract and you're doing phenomenally. Let's keep going!
+We're already through over half the opcodes of our contract and you're doing phenomenally. Let's keep going!

--- a/courses/formal-verification/1-horse-store/5-huff-main-macro/+page.md
+++ b/courses/formal-verification/1-horse-store/5-huff-main-macro/+page.md
@@ -8,7 +8,7 @@ _Follow along with this video:_
 
 In a way, sending our `calldata` to the blockchain is like executing a Python or JavaScript script. We need to begin with an `entry point` in order for our `calldata` to be processed.
 
-In Huff, this entry point is called `MAIN`. Essentially, `MAIN` in the binary becomes the recipient of your call data and orchestrates its execution. We'll go into this in more detail later.
+In Huff, this entry point is called `MAIN`. Essentially, `MAIN` in the binary becomes the recipient of your calldata and orchestrates its execution. We'll go into this in more detail later.
 
 Now, if you feel a bit overwhelmed by the barrage of terminology, hang in there with me. I promise it'll all start making a lot more sense as we delve deeper.
 

--- a/courses/formal-verification/1-horse-store/50-setting-up-jumpdest-program-counters/+page.md
+++ b/courses/formal-verification/1-horse-store/50-setting-up-jumpdest-program-counters/+page.md
@@ -192,6 +192,6 @@ DUP1
 REVERT
 ```
 
-This is our `updateNumberOfHorses()` jump dest 2. A great way to determine these jump destinations would be to copy your op codes into the [evm.codes playground](https://www.evm.codes/playground) and reference the locations jumped when stepping through the execution.
+This is our `updateNumberOfHorses()` jump dest 2. A great way to determine these jump destinations would be to copy your opcodes into the [evm.codes playground](https://www.evm.codes/playground) and reference the locations jumped when stepping through the execution.
 
 Let's see what this `JUMPDEST` does in the next lesson!

--- a/courses/formal-verification/1-horse-store/51-checking-if-call-data-is-big-enough-to-contain-a-uint256/+page.md
+++ b/courses/formal-verification/1-horse-store/51-checking-if-call-data-is-big-enough-to-contain-a-uint256/+page.md
@@ -177,13 +177,13 @@ Our stack is getting a little crazy, but each step should be pretty clear to us,
 
 ![checking-call-data-size1](/formal-verification-1/51-Checking-If-Call-Data-Is-Big-Enough-To-Contain-A-Uint256/checking-call-data-size1.png)
 
-In essence the DUP3 op code is taking the third item from the top of the stack and duplicating it, adding this copy to the top of the stack. Given this, what do you think DUP5 does?
+In essence the DUP3 opcode is taking the third item from the top of the stack and duplicating it, adding this copy to the top of the stack. Given this, what do you think DUP5 does?
 
 ![checking-call-data-size2](/formal-verification-1/51-Checking-If-Call-Data-Is-Big-Enough-To-Contain-A-Uint256/checking-call-data-size2.png)
 
 Shocking, I know.
 
-Next we see two more op codes we've not come across yet `SUB` and `SLT`
+Next we see two more opcodes we've not come across yet `SUB` and `SLT`
 
 `SUB` is quite simply - subtraction. It's going to take the top item of our stack and subtract from it the second from top item in our stack.
 
@@ -195,15 +195,15 @@ Next we see two more op codes we've not come across yet `SUB` and `SLT`
 
 We can see the steps, but what are these operations actually doing?
 
-Well, when we `DUP3` > `DUP5` we are setting up an assessment of our `call data` by then calling `SUB` we're performing the operation `calldata_size - 0x04` which gives us a number which represents if our call data was greater than 4 bytes in size - remember 4 bytes is the size of our `function selector`.
+Well, when we `DUP3` > `DUP5` we are setting up an assessment of our `calldata` by then calling `SUB` we're performing the operation `calldata_size - 0x04` which gives us a number which represents if our calldata was greater than 4 bytes in size - remember 4 bytes is the size of our `function selector`.
 
 The next operation is `SLT` and here's where `0x20` being 32 is important.
 
 We compare the result of `calldata_size - 0x04` with `0x20`. So we're asking:
 
-**_If we remove what we expect to be the size of a function selector, is the remaining call data less than 32 bytes?_**
+**_If we remove what we expect to be the size of a function selector, is the remaining calldata less than 32 bytes?_**
 
-This check is going to assure that call data being passed to this function is greater than 32 bytes (which is what a uint256 parameter would be!). We then call `ISZERO` and `PUSH1 0x68`, and finally `JUMPI` if the call data is the appropriate size.
+This check is going to assure that calldata being passed to this function is greater than 32 bytes (which is what a uint256 parameter would be!). We then call `ISZERO` and `PUSH1 0x68`, and finally `JUMPI` if the calldata is the appropriate size.
 
 ```js
 DUP3         // [0x04, 0x20, 0x00, 0x04, calldata_size, 0x3f, 0x43, func_selector]
@@ -213,10 +213,10 @@ SLT          // [(calldata_size - 0x04) < 0x20, 0x00, 0x04, calldata_size, 0x3f,
 ISZERO       // [((calldata_size - 0x04) < 0x20) == 0, 0x00, 0x04, calldata_size, 0x3f, 0x43, func_selector]
 PUSH1 0x68   // [0x68, ((calldata_size - 0x04) < 0x20) == 0, 0x00, 0x04, calldata_size, 0x3f, 0x43, func_selector]
 JUMPI        // [0x00, 0x04, calldata_size, 0x3f, 0x43, func_selector]
-// Jump to jump dest 3 if there is more call data than function selector + 0x20!
+// Jump to jump dest 3 if there is more calldata than function selector + 0x20!
 ```
 
-If the call data received, less the size of the function selector is _not_ 32 bytes in size, execution won't jump and we see what happens next - a revert block!
+If the calldata received, less the size of the function selector is _not_ 32 bytes in size, execution won't jump and we see what happens next - a revert block!
 
 ```js
 JUMPI; // [0x00, 0x04, calldata_size, 0x3f, 0x43, func_selector]

--- a/courses/formal-verification/1-horse-store/52-sstoreing-our-value/+page.md
+++ b/courses/formal-verification/1-horse-store/52-sstoreing-our-value/+page.md
@@ -171,11 +171,11 @@ JUMP;
 
 The first thing we do at jump dest 3 is execute `POP`. This just removes the top item of our stack `0x00`. We then perform `CALLDATALOAD`, which we've seen before.
 
-`CALLDATALOAD` takes a bytes offset as a stack input, and outputs 32 Bytes of data from our call data, starting at the bytes offset.
+`CALLDATALOAD` takes a bytes offset as a stack input, and outputs 32 Bytes of data from our calldata, starting at the bytes offset.
 
-In our example, we're providing `0x04` (the size of our `function selector`) and adding our call data, less this `function selector`, to the top of our stack.
+In our example, we're providing `0x04` (the size of our `function selector`) and adding our calldata, less this `function selector`, to the top of our stack.
 
-Now we see a new op code, `SWAP2`!
+Now we see a new opcode, `SWAP2`!
 
 ![sstoreing-our-value1](/formal-verification-1/52-sstoreing-our-value/sstoreing-our-value1.png)
 
@@ -200,9 +200,9 @@ JUMP; // [CALLDATA[4:], 0x43, func_selector]
 
 And, given what we've seen with `SWAP2`, I'm sure we can speculate what `SWAP1` is going to do! That's right, it will swap the top item of our stack with the second from the top (or first index) item.
 
-Next we `POP` our `calldata_size` off of our stack and then call `JUMP`. The `JUMPDEST` is going to be what's at the top of our stack currently, which is `0x3f`, and we're bringing our `call data` with us!
+Next we `POP` our `calldata_size` off of our stack and then call `JUMP`. The `JUMPDEST` is going to be what's at the top of our stack currently, which is `0x3f`, and we're bringing our `calldata` with us!
 
-Look at our updated op code list to see where we've jumped to now, we're about to finally call `SSTORE` to save our new horse number to storage!
+Look at our updated opcode list to see where we've jumped to now, we're about to finally call `SSTORE` to save our new horse number to storage!
 
 <details>
 <Summary> Op Codes </summary>
@@ -360,8 +360,8 @@ From jump dest 4, we're able to finally save our value to storage, but we've onl
 
 1. Our `function selector` matched and our function was dispatched
 2. We passed the `msg.value check`
-3. Our `call data` was long enough to possibly include a valid value for storage (32 bytes)
-4. we've isolated our passed parameter data from our total `call data`
+3. Our `calldata` was long enough to possibly include a valid value for storage (32 bytes)
+4. we've isolated our passed parameter data from our total `calldata`
 
 ```js
 JUMPDEST; // [CALLDATA[4:], 0x43, func_selector]
@@ -382,4 +382,4 @@ JUMPDEST; // [func_selector]
 STOP; // []
 ```
 
-This final chunk of this transaction simply ends execution. This is great! We've walk through every op code, end to end when calling the `updateNumberOfHorses()` function!
+This final chunk of this transaction simply ends execution. This is great! We've walk through every opcode, end to end when calling the `updateNumberOfHorses()` function!

--- a/courses/formal-verification/1-horse-store/53-update-horse-number-recap/+page.md
+++ b/courses/formal-verification/1-horse-store/53-update-horse-number-recap/+page.md
@@ -168,7 +168,7 @@ We just went through the entire execution of the `updateHorseNumber` function, S
 
 ### Function Dispatch
 
-The first thing our contract does is perform a `function dispatch` to determine where our `call data` should be appropriately sent.
+The first thing our contract does is perform a `function dispatch` to determine where our `calldata` should be appropriately sent.
 
 ```js
 DUP1 ✅
@@ -189,7 +189,7 @@ DUP1 ✅
 REVERT ✅
 ```
 
-If call data doesn't include a function selector which matches the transaction will revert.
+If calldata doesn't include a function selector which matches the transaction will revert.
 
 ### Program Counters
 
@@ -224,7 +224,7 @@ JUMPI ✅
 
 ### Isolating Passed Data
 
-If the `call data` passes this size check, we next jump and isolate the parameter from the `call data` by loading 32 bytes of `call data` starting at `0x04`:
+If the `calldata` passes this size check, we next jump and isolate the parameter from the `calldata` by loading 32 bytes of `calldata` starting at `0x04`:
 
 ```js
 JUMPDEST ✅

--- a/courses/formal-verification/1-horse-store/54-readNumberOfHorses-op-codes/+page.md
+++ b/courses/formal-verification/1-horse-store/54-readNumberOfHorses-op-codes/+page.md
@@ -188,7 +188,7 @@ PUSH1 0x45         // [0x45, 0xe026c017 == func_selector, func_selector]
 JUMPI              // [func_selector]
 ```
 
-`PUSH1 0x45` is pushing a `JUMPDEST` to the top of our stack, and finally `JUMPI` is jumping if the `call data` `function selector` is found to be equal to the known `function selector`.
+`PUSH1 0x45` is pushing a `JUMPDEST` to the top of our stack, and finally `JUMPI` is jumping if the `calldata` `function selector` is found to be equal to the known `function selector`.
 
 There's just one `JUMPDEST` for `readNumberOfHorses`, but it's a lot.
 
@@ -283,7 +283,7 @@ This seems like a lot but it makes sense when broken down a bit. We first `PUSH1
 
 ### Wrap Up
 
-With that we have walked through every single op code in this contract's creation and runtime bytecode! We noticed that our Huff implementation can definitely be more efficient than Solidity because we by pass a few checks (for better or worse) and don't have to manage a `free memory pointer`!
+With that we have walked through every single opcode in this contract's creation and runtime bytecode! We noticed that our Huff implementation can definitely be more efficient than Solidity because we by pass a few checks (for better or worse) and don't have to manage a `free memory pointer`!
 
 Here's where we've come so far:
 

--- a/courses/formal-verification/1-horse-store/55-metadata/+page.md
+++ b/courses/formal-verification/1-horse-store/55-metadata/+page.md
@@ -8,7 +8,7 @@ _Follow along with this video:_
 
 ### Metadata
 
-Alright! We've gone through all of the contract's `creation code` and `runtime code`. All that's left is the `metadata` ...it kinda looks like a mess at the end of our contract's op codes.
+Alright! We've gone through all of the contract's `creation code` and `runtime code`. All that's left is the `metadata` ...it kinda looks like a mess at the end of our contract's opcodes.
 
 ```js
 LOG2

--- a/courses/formal-verification/1-horse-store/56-decompilers-disassembly/+page.md
+++ b/courses/formal-verification/1-horse-store/56-decompilers-disassembly/+page.md
@@ -6,7 +6,7 @@ _Follow along with this video:_
 
 ---
 
-Alright! We've gone op code by op code and break down our Solidity contract's bytecode. At this point we could maybe even decompile our contract back into some semblence of Solidity code by following through the execution!
+Alright! We've gone opcode by opcode and break down our Solidity contract's bytecode. At this point we could maybe even decompile our contract back into some semblence of Solidity code by following through the execution!
 
 This isn't something we necessarily have to do ourselves though. There exist tool such as [Dedaub](https://app.dedaub.com/decompile) that can try to decompile byte code for us!
 

--- a/courses/formal-verification/1-horse-store/57-compiled-solodity-op-code-recap/+page.md
+++ b/courses/formal-verification/1-horse-store/57-compiled-solodity-op-code-recap/+page.md
@@ -8,11 +8,11 @@ _Follow along with this video:_
 
 ### Recap
 
-Ok, we've learn a lot in this section, let's take one more moment to summarize everything we've gone through. This will be the only time we go op code by op code - unless we have to 🤷‍♂️
+Ok, we've learn a lot in this section, let's take one more moment to summarize everything we've gone through. This will be the only time we go opcode by opcode - unless we have to 🤷‍♂️
 
 Maybe we're dealing with Assembly, or auditing a compiler or super optimizing a contract - this skill set can be very useful when things get low level or difficult.
 
-We've mentioned it often, but if you want to familiarize yourself even further with all the different op codes in the EVM absolutely check out [evm.codes](https://www.evm.codes/#34?fork=cancun). If you don't feel comfortable with op codes yet, the more you play with them the better you will be.
+We've mentioned it often, but if you want to familiarize yourself even further with all the different opcodes in the EVM absolutely check out [evm.codes](https://www.evm.codes/#34?fork=cancun). If you don't feel comfortable with opcodes yet, the more you play with them the better you will be.
 
 ---
 In this section we learnt that most smart contracts are compiled into 3 sections:
@@ -33,7 +33,7 @@ MSTORE
 
 We didn't update it often in our codebase, but we can see that if accessing memory often we would need to consistently keep track of where free memory is located by updating this pointer.
 
-We learnt that Solidity, at the op code level, performs a bunch of checks, like checking `call data` for msg.value and assuring `call data` being passed is of the correct size.
+We learnt that Solidity, at the opcode level, performs a bunch of checks, like checking `calldata` for msg.value and assuring `calldata` being passed is of the correct size.
 
 msg.value check:
 ```js
@@ -55,7 +55,7 @@ PUSH1 0x59 ✅
 JUMP ✅
 ```
 
-We also learnt that our Contract Creation code is going to contain the CODECOPY op code  which is why executes putting our contract on-chain.
+We also learnt that our Contract Creation code is going to contain the CODECOPY opcode  which is why executes putting our contract on-chain.
 
 ```js
 JUMPDEST ✅
@@ -70,9 +70,9 @@ RETURN ✅
 INVALID ✅
 ```
 
-In Solidity, we determined that the `runtime code` was going to be the entry point of our contract for any `call data` passed to it, and functions similarly to the `MAIN()` macro we wrote in Huff
+In Solidity, we determined that the `runtime code` was going to be the entry point of our contract for any `calldata` passed to it, and functions similarly to the `MAIN()` macro we wrote in Huff
 
-We discovered how Solidity's `function dispatching` works, after all the checks are passed! The dispatcher will compare the first 4 bytes of our received call data to find a match with the known `function selectors` of our contract and will use any found matches to route our execution to the appropriate `JUMPDEST`
+We discovered how Solidity's `function dispatching` works, after all the checks are passed! The dispatcher will compare the first 4 bytes of our received calldata to find a match with the known `function selectors` of our contract and will use any found matches to route our execution to the appropriate `JUMPDEST`
 
 ```js
 PUSH0 ✅
@@ -93,8 +93,8 @@ PUSH1 0x45 ✅
 JUMPI ✅
 ```
 
-We even learnt how to reference and manipulate the free memory pointer and saving and loading for storage! We've literally walked through every single op code and disassembled this entire contract and stepped through what each of these op codes is doing.
+We even learnt how to reference and manipulate the free memory pointer and saving and loading for storage! We've literally walked through every single opcode and disassembled this entire contract and stepped through what each of these opcodes is doing.
 
-I cannot encourage you enough to tinker and explore with how all these works.  Change the contract, write your own, investigate how the bytecode and subsequent op codes changes.
+I cannot encourage you enough to tinker and explore with how all these works.  Change the contract, write your own, investigate how the bytecode and subsequent opcodes changes.
 
 It's in this discovery that you will make the important mental connections pertaining to how the evm and contracts work together.

--- a/courses/formal-verification/1-horse-store/58-precompiles/+page.md
+++ b/courses/formal-verification/1-horse-store/58-precompiles/+page.md
@@ -10,9 +10,9 @@ _Follow along with this video:_
 
 One tricky thing that stands out, which we haven't gone over are `precompiles`. So let's quickly detail how they work.
 
-`Precompiles` are effectively fixed address contracts that come bundled with the EVM and perform certain tasks. They function similarly to op codes when compiled and are worth keeping an eye out for when decompiling contracts.
+`Precompiles` are effectively fixed address contracts that come bundled with the EVM and perform certain tasks. They function similarly to opcodes when compiled and are worth keeping an eye out for when decompiling contracts.
 
-If you see a hardcoded address in a contract's op codes, they may be working with a precompile. Similarly, if you see STATICCALL being used on a weird address like `0x01`, they may as well being interacting with a precompile.
+If you see a hardcoded address in a contract's opcodes, they may be working with a precompile. Similarly, if you see STATICCALL being used on a weird address like `0x01`, they may as well being interacting with a precompile.
 
 We briefly touch on a couple precompiles such as `ecrecover` and `SHA2-256` in the [Security Course on Cyfrin Updraft](https://updraft.cyfrin.io/courses/security), so definitely check that out.
 

--- a/courses/formal-verification/1-horse-store/60-inline-assembly/+page.md
+++ b/courses/formal-verification/1-horse-store/60-inline-assembly/+page.md
@@ -31,7 +31,7 @@ contract HorseStore {
 }
 ```
 
-In order to access Yul, we just need to wrap our operations in an `assembly` object, as shown above. From here we can access op codes almost like functions, with the stack layer of consideration abstracted away for us.
+In order to access Yul, we just need to wrap our operations in an `assembly` object, as shown above. From here we can access opcodes almost like functions, with the stack layer of consideration abstracted away for us.
 
 ```js
 function updateHorseNumber(uint256 newNumberOfHorses) external {
@@ -41,7 +41,7 @@ function updateHorseNumber(uint256 newNumberOfHorses) external {
 }
 ```
 
-In this example we see `sstore()` being used like our SSTORE op code, with the stack inputs being passed as parameters. The first input is the storage slot we're storing our data to, and the second input is the data we're storing. That's all it takes to `updateHorseNumber`!
+In this example we see `sstore()` being used like our SSTORE opcode, with the stack inputs being passed as parameters. The first input is the storage slot we're storing our data to, and the second input is the data we're storing. That's all it takes to `updateHorseNumber`!
 
 ```js
 function readNumberOfHorses() external view returns (uint256) {

--- a/courses/formal-verification/1-horse-store/61-pure-yul/+page.md
+++ b/courses/formal-verification/1-horse-store/61-pure-yul/+page.md
@@ -43,7 +43,7 @@ Datacopy, dataoffset and datasize might seem unfamiliar, but these are function 
 
 ![pure-yul1](/formal-verification-1/61-pure-yul/pure-yul1.png)
 
-We can see that in our circumstances the `datacopy` function is being used as equivalent to the `codecopy` op code, and what does `codecopy` do? Well, it's taking the size and offset of our `runtime code` (we haven't written the `runtime` yet!) and returning it to be copied to the blockchain!
+We can see that in our circumstances the `datacopy` function is being used as equivalent to the `codecopy` opcode, and what does `codecopy` do? Well, it's taking the size and offset of our `runtime code` (we haven't written the `runtime` yet!) and returning it to be copied to the blockchain!
 
 ```js
 object "HorseStoreYul" {
@@ -139,13 +139,13 @@ Let's breakdown `selector()` a bit because it is wild.
 
 Basically, when this function is called it returns a variable `s`. Return, in Yul, is denoted by `->`, so `return s` == `-> s`.
 
-Then, within the `selector()` function we're dividing our `call data` (accessed via `calldataload(0)`), by `0x10000000000000000000000000000000000000000000000000000000` and assigning the value to our `s` variable.
+Then, within the `selector()` function we're dividing our `calldata` (accessed via `calldataload(0)`), by `0x10000000000000000000000000000000000000000000000000000000` and assigning the value to our `s` variable.
 
-> **Note:** the number `0x10000000000000000000000000000000000000000000000000000000` is effectively removing 28 bytes from our call data, leaving us with the first 4 bytes - or our `function selector` to compare to our `switch` cases!
+> **Note:** the number `0x10000000000000000000000000000000000000000000000000000000` is effectively removing 28 bytes from our calldata, leaving us with the first 4 bytes - or our `function selector` to compare to our `switch` cases!
 
 ### Switch Case Logic
 
-Now that we've isolated our `function selector` from our `call data`, we should have some logic for it to get routed to base on which `switch case` triggers. Let's start with `updateHorseNumber`
+Now that we've isolated our `function selector` from our `calldata`, we should have some logic for it to get routed to base on which `switch case` triggers. Let's start with `updateHorseNumber`
 
 ```js
 case 0xcdfead2e {
@@ -177,7 +177,7 @@ Our `decodeAsUint()` function is taking an `offset` as a parameter (we've passed
 
 Because our `offset` is 0, our positionInCallData is going to be starting at 4 bytes, or immediately following our function selector.
 
-We then assign a value to our return value, v. `calldataload()` will load 32 bytes of `call data` starting from a passed `offset`, which in our case is immediately following our `function selector` and hopefully this will be the value that we're updating!
+We then assign a value to our return value, v. `calldataload()` will load 32 bytes of `calldata` starting from a passed `offset`, which in our case is immediately following our `function selector` and hopefully this will be the value that we're updating!
 
 ### storeNumber
 
@@ -350,7 +350,7 @@ object "HorseStoreYul" {
 
 There's also a `runtime` object, which contains our contracts `runtime` logic within _its_ `code` section.
 
-We learnt that the first thing we do, just like in Huff and Solidity is employ a `function dispatcher` and that the Yul `function dispatcher` uses `switch `cases to route logic to the case which matches our `call data`'s `function selector`.
+We learnt that the first thing we do, just like in Huff and Solidity is employ a `function dispatcher` and that the Yul `function dispatcher` uses `switch `cases to route logic to the case which matches our `calldata`'s `function selector`.
 
 And finally, we learnt the value of leveraging helper functions like decodeAsUint and returnUint to load the necessary data for our functions in and out of storage and memory.
 

--- a/courses/formal-verification/1-horse-store/63-horsestorev2-huff-function-dispatch/+page.md
+++ b/courses/formal-verification/1-horse-store/63-horsestorev2-huff-function-dispatch/+page.md
@@ -16,9 +16,9 @@ Now that we've been through this once before, we should be a little more familia
 }
 ```
 
-> **Protip:**With a little deeper understanding of op codes now, I can further highlight what `takes (0) returns (0)` is doing.  These values are what we are taking off the stack and returning to the stack if we wanted our contract to do anything like this, this is where it would happen!
+> **Protip:**With a little deeper understanding of opcodes now, I can further highlight what `takes (0) returns (0)` is doing.  These values are what we are taking off the stack and returning to the stack if we wanted our contract to do anything like this, this is where it would happen!
 
-Now let's consider what we need to set up our function dispatcher in Huff for this contract. We know that getting the function selector from call data is going to be the exact same as we did before:
+Now let's consider what we need to set up our function dispatcher in Huff for this contract. We know that getting the function selector from calldata is going to be the exact same as we did before:
 
 ```js
 #define macro MAIN() = takes (0) returns (0){
@@ -28,7 +28,7 @@ Now let's consider what we need to set up our function dispatcher in Huff for th
 
 What else do we need?
 
-Well, we're going to need the function selectors of each of the functions in our contract to which we will compare the call data received to. These should be:
+Well, we're going to need the function selectors of each of the functions in our contract to which we will compare the calldata received to. These should be:
 
 - `mintHorse()`
 - `feedHorse()`
@@ -74,7 +74,7 @@ Let's add these to our function dispatcher, just like we did before. We could us
 }
 ```
 
-As you can see, this is all the same as we've done in our simple `HorseStoreV1` contract, it's just dialed up a bit. We've created an interface which references all of our functions and added the checks for each of their `function signatures` vs the received `call data` of our `MAIN macro`.
+As you can see, this is all the same as we've done in our simple `HorseStoreV1` contract, it's just dialed up a bit. We've created an interface which references all of our functions and added the checks for each of their `function signatures` vs the received `calldata` of our `MAIN macro`.
 
 Finally, we've set up jump destinations which will be jumped to when a match is found with one of our `function selectors`!  Each of these jump destinations pertains to a specific `macro`, which we have yet to write.  
 

--- a/courses/formal-verification/1-horse-store/64-feedHorse-macro/+page.md
+++ b/courses/formal-verification/1-horse-store/64-feedHorse-macro/+page.md
@@ -56,11 +56,11 @@ function feedHorse(uint256 horseId) external {
 
 This is going to one of the most important functions we learn about in this section as we'll be touching on `timestamps` _and_ `mappings`!
 
-We're going to need to access the block's timestamp, fortunately there's an op code that does just this `TIMESTAMP`.
+We're going to need to access the block's timestamp, fortunately there's an opcode that does just this `TIMESTAMP`.
 
 ![feedhorse_macro1](/formal-verification-1/64-feedhorse-macro/feedhorse_macro1.png)
 
-So, our function takes a `uint256 horseId`, we're going to want to add this to our stack as well. We know how to do this with the op code `calldataload`, which takes an offset, then adds 32 bytes of call data from the offset to our stack.
+So, our function takes a `uint256 horseId`, we're going to want to add this to our stack as well. We know how to do this with the opcode `calldataload`, which takes an offset, then adds 32 bytes of calldata from the offset to our stack.
 
 ```js
 #define macro FEED_HORSE() = takes(0) returns (0) {

--- a/courses/formal-verification/1-horse-store/65-mappings-and-arrays-in-evm-huff/+page.md
+++ b/courses/formal-verification/1-horse-store/65-mappings-and-arrays-in-evm-huff/+page.md
@@ -134,4 +134,4 @@ We can just call this `STORE_ELEMENT_FROM_KEYS()` macro within our `FEED_HORSE()
 }
 ```
 
-And that's all there is for our `FEED_HORSE()` macro! `Hashmap.huff` made things pretty painless for us, but if you find yourself not quite understanding how things were calculated, I encourage you to go into the macros of `Hashmap.huff` and walk yourself through the op codes to gain a deeper understanding of what they're doing before continuing.
+And that's all there is for our `FEED_HORSE()` macro! `Hashmap.huff` made things pretty painless for us, but if you find yourself not quite understanding how things were calculated, I encourage you to go into the macros of `Hashmap.huff` and walk yourself through the opcodes to gain a deeper understanding of what they're doing before continuing.

--- a/courses/formal-verification/1-horse-store/66-horseidtofedtimestamp/+page.md
+++ b/courses/formal-verification/1-horse-store/66-horseidtofedtimestamp/+page.md
@@ -79,7 +79,7 @@ Now let's define this macro!
 
 So, what's this macro doing?
 
-We're first getting the `horseId` from our call data via `calldataload` at the `0x04` offset.  We then add the `HORSE_FED_TIMESTAMP_LOCATION` storage slot onto our stack.
+We're first getting the `horseId` from our calldata via `calldataload` at the `0x04` offset.  We then add the `HORSE_FED_TIMESTAMP_LOCATION` storage slot onto our stack.
 
 We next use another `Hashmap.huff` macro `LOAD_ELEMENT_FROM_KEYS`. This functions much like the reverse of our previous `STORE_ELEMENT_FROM_KEYS` in that we are taking the location of the mapping (`HORSE_FED_TIMESTAMP_LOCATION`) and passing it our horseId key. The macro is then returning to our stack the appropriate data mapped to that key - `horseFedTimestamp`.
 

--- a/courses/formal-verification/1-horse-store/67-ishappyhorse/+page.md
+++ b/courses/formal-verification/1-horse-store/67-ishappyhorse/+page.md
@@ -75,7 +75,7 @@ function isHappyHorse(uint256 horseId) external view returns (bool) {
 
 There are conditionals and comparisons galore! We're going to have to go through each of these to determine what will be returned by our macro.
 
-The start shouldn't be too complicated, we're going to need the parameter being passed (our horseId from `call data`), and we use this to load the horseFedTimestamp, just like we did in the `GET_HORSE_FED_TIMESTAMP()` macro. We also need the current timestamp to calculate the value we're comparing.
+The start shouldn't be too complicated, we're going to need the parameter being passed (our horseId from `calldata`), and we use this to load the horseFedTimestamp, just like we did in the `GET_HORSE_FED_TIMESTAMP()` macro. We also need the current timestamp to calculate the value we're comparing.
 
 ```js
 #define macro IS_HAPPY_HORSE() = takes (0) returns (0) {
@@ -109,7 +109,7 @@ Let's define this in our Huff contract. For convenience, `1 days` in hex is `0x0
 #define constant HORSE_HAPPY_IF_FED_WITHIN_CONST = 0x0000000000000000000000000000000000000000000000000000000000015180
 ```
 
-Let's add this constant to our stack, in our macro and finally compare our previous calculation to it using the `gt` op code. This will perform a greater than comparison taking our top two items on the stack as inputs.
+Let's add this constant to our stack, in our macro and finally compare our previous calculation to it using the `gt` opcode. This will perform a greater than comparison taking our top two items on the stack as inputs.
 
 ```js
 #define macro IS_HAPPY_HORSE() = takes (0) returns (0) {
@@ -144,7 +144,7 @@ This is a little confusing at first glance, but let's step through it together.
 
 We start with the bool `horse_has_been_fed_within_1_day` on the top of our stack, if this is true, we jump to `start_return_true` and push `0x01` to our stack (this is ultimately our return value saying `IS_HAPPY_HORSE == True`). Execution then continues by storing `0x01` in memory and returning this as our function's result.
 
-If the bool `horse_has_been_fed_within_1_day` is false (or 0) we know the horse hasn't been bed in less than 1 day, we then check to see if the horse was fed at exactly 1 day with the `eq` op code. When then do a hard jump to `start_return`.
+If the bool `horse_has_been_fed_within_1_day` is false (or 0) we know the horse hasn't been bed in less than 1 day, we then check to see if the horse was fed at exactly 1 day with the `eq` opcode. When then do a hard jump to `start_return`.
 
 The `start_return` jump destination continues execution by storing the top item of our stack into memory and returning 32 bytes of that item. The item returned is going to be `0x01` or `0x00` depending on if the horse was fed at exactly 1 day.
 

--- a/courses/formal-verification/1-horse-store/68-a-quick-function-then-huffmate/+page.md
+++ b/courses/formal-verification/1-horse-store/68-a-quick-function-then-huffmate/+page.md
@@ -855,11 +855,11 @@ We can finally begin defining our `MINT_HORSE()` macro:
 }
 ```
 
-Next we'll need to access the msg.sender, as that's to whom the token is being minted. Fortunately we've an op code specifically to reference the `CALLER`.
+Next we'll need to access the msg.sender, as that's to whom the token is being minted. Fortunately we've an opcode specifically to reference the `CALLER`.
 
 ![a-quick-function-then-huffmate1](/formal-verification-1/68-a-quick-function-then-huffmate/a-quick-function-then-huffmate1.png)
 
-This op code will add the 20 byte address of the callers account to the top of our stack!
+This opcode will add the 20 byte address of the callers account to the top of our stack!
 
 Once we have the `msg.sender` and the current `totalSupply`, we can use one of the macros we inherited from Huffmate's ERC721 implementation: `MINT()`.
 

--- a/courses/formal-verification/1-horse-store/7-smart-contract-bytecode/+page.md
+++ b/courses/formal-verification/1-horse-store/7-smart-contract-bytecode/+page.md
@@ -18,13 +18,13 @@ Well, if you assess the input `calldata` of a transaction, most compiled contrac
 
 <smart-contracts.png>
 
-> The Solidity compiler is nice in that it adds a bit of op code syntax in the form of an `INVALID` code between each of these distinct sections.
+> The Solidity compiler is nice in that it adds a bit of opcode syntax in the form of an `INVALID` code between each of these distinct sections.
 
 ### Contract Creation
 
 The `contract creation` section of the bytecode is what tells the blockchain to actually store a contract in the database. It says **_"Hey, take the binary after me, and stick it on-chain."_**
 
-What we're seeing as an output when we run `huffc src/horseStoreV1/HorseStore.huff` is the bytecode which represents this contract creation in op codes. Even though we don't have any logic or `Runtime` code in our contract, Huff is smart enough to know that we need these operations in order to create the contract at all.
+What we're seeing as an output when we run `huffc src/horseStoreV1/HorseStore.huff` is the bytecode which represents this contract creation in opcodes. Even though we don't have any logic or `Runtime` code in our contract, Huff is smart enough to know that we need these operations in order to create the contract at all.
 
 By the time we complete our Huff implementation, we should have bytecode generated for both contract creation and runtime. We could include metadata, but for our purposes we won't.
 
@@ -32,6 +32,6 @@ By the time we complete our Huff implementation, we should have bytecode generat
 
 ### Wrap Up
 
-We're easing into our understanding of op codes and how they govern executions on the blockchain. In this lesson we learnt that the input `calldata` of a contract is broken into 3 distinct sections, one of which-`Contract Creation`- is responsible exclusively for saving our contract on-chain.
+We're easing into our understanding of opcodes and how they govern executions on the blockchain. In this lesson we learnt that the input `calldata` of a contract is broken into 3 distinct sections, one of which-`Contract Creation`- is responsible exclusively for saving our contract on-chain.
 
 In the next lesson, let's look more closely at how this section of `calldata` accomplishes just that!

--- a/courses/formal-verification/1-horse-store/70-huff-yul-and-solidity-gas-comparisons/+page.md
+++ b/courses/formal-verification/1-horse-store/70-huff-yul-and-solidity-gas-comparisons/+page.md
@@ -46,4 +46,4 @@ Huff wins again! Let's look at one comparison from HorseStoreV2:
 
 Wow! It's nearly 10,000 more gas in raw Solidity than it is in raw Huff. When looking at comparisons like this, it's easy to begin to see the advantages of coding in low level languages like Huff and Yul.
 
-Always remember the trade-offs that are made to save this gas however. This saved gas we see is a product of all the checks we skipped the implementation of in Huff, checks meant to keep people safe. We skipped checking for msg.value and call data length for example. These checks exist for a reason and we should be confident and conscientious when we choose to omit them.
+Always remember the trade-offs that are made to save this gas however. This saved gas we see is a product of all the checks we skipped the implementation of in Huff, checks meant to keep people safe. We skipped checking for msg.value and calldata length for example. These checks exist for a reason and we should be confident and conscientious when we choose to omit them.

--- a/courses/formal-verification/1-horse-store/71-section-1-horsestore-recap/+page.md
+++ b/courses/formal-verification/1-horse-store/71-section-1-horsestore-recap/+page.md
@@ -27,8 +27,8 @@ MSTORE      // []  // Memory: 0x40:0x80
 
 ### Breaking Down Solidity
 
-Something else we covered was the process of breaking down a Solidity smart contract into it's op codes and we walked through exactly how one of these contracts functions, code by code and learnt what every single op code it contained does. [evm.codes](https://www.evm.codes) as a reference point for op codes is an _invaluable_ resource, use it well.
-In learning about op codes we also introduced Huff as a low level programming language that allows developers the potential save a great deal of gas by optimizing the op codes a smart contract uses.
+Something else we covered was the process of breaking down a Solidity smart contract into it's opcodes and we walked through exactly how one of these contracts functions, code by code and learnt what every single opcode it contained does. [evm.codes](https://www.evm.codes) as a reference point for opcodes is an _invaluable_ resource, use it well.
+In learning about opcodes we also introduced Huff as a low level programming language that allows developers the potential save a great deal of gas by optimizing the opcodes a smart contract uses.
 In addition to Huff we touched briefly on Yul and how we can leverage Yul for inline assembly to allow granular control over smart contract functionality and gas costs directly in our Solidity smart contracts. While investigating Yul, we even wrote an entire smart contract in Yul! This isn't normal, but it sure was fun.
 
 ### Testing
@@ -40,7 +40,7 @@ This also allowed us to directly compare gas costs of each of these implementati
 
 Briefly we experimented with Foundry's Debugger which is accessed with
 `forge --debug <testName>`
-This will allow us to step through our test's execution, op code by op code, much like the [evm.codes playground](https://www.evm.codes/playground).
+This will allow us to step through our test's execution, opcode by opcode, much like the [evm.codes playground](https://www.evm.codes/playground).
 
 ### Complex, Low Level Contracts
 
@@ -49,7 +49,7 @@ One of the biggest things we did in this section was write a complex contract al
 - imports
 - ERC721s
 - Mappings
-  These are not simple concepts when working directly with op codes and having mastered them here you'll be well prepared.
+  These are not simple concepts when working directly with opcodes and having mastered them here you'll be well prepared.
   During this process we learnt the value of libraries like `Huffmate` to do the heavy lifting when programming in low level code.
 
 ### Bytecode
@@ -59,12 +59,12 @@ We learnt that smart contracts when compiled can be broken into 3 distinct secti
 1. Contract Creation Code
 2. Runtime Code
 3. Metadata
-   We now have the ability to translate these sections of bytecode into op codes and derive what a smart contract is doing - whether or not it's been verified! This is an incredibly powerful skill in security research.
+   We now have the ability to translate these sections of bytecode into opcodes and derive what a smart contract is doing - whether or not it's been verified! This is an incredibly powerful skill in security research.
 
 ### Wrap Up
 
 In closing, I'll say: if you still don't quite get this, or it's not clicking. That's ok. There aren't a lot of smart contracts written in Huff. There _are_ a lot of smart contracts which are written in assembly or leverage inline assemble, which is something we'll cover in more detail in Section 2 of this course.
-However, in order to really understand the assembly, you really have to understand the op codes and I think one of the best ways to become familiar with op codes is to code in Huff. I encourage you to practice this!
+However, in order to really understand the assembly, you really have to understand the opcodes and I think one of the best ways to become familiar with opcodes is to code in Huff. I encourage you to practice this!
 With this, you've completed Section 1 of the EVM/Formal Verification Course! Go take a break, you've earned it!
 
 🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴🐴

--- a/courses/formal-verification/1-horse-store/8-codecopy-opcode/+page.md
+++ b/courses/formal-verification/1-horse-store/8-codecopy-opcode/+page.md
@@ -8,7 +8,7 @@ _Follow along with this video:_
 
 ### CODECOPY
 
-Before moving forward, there's one specific op code that I wanted to bring to your attention, `CODECOPY`. Represented by the hexadecimal `39`, this op code is a clear indication of where `Contract Creation` occurs in bytecode (though this can also be seen in Runtime).
+Before moving forward, there's one specific opcode that I wanted to bring to your attention, `CODECOPY`. Represented by the hexadecimal `39`, this opcode is a clear indication of where `Contract Creation` occurs in bytecode (though this can also be seen in Runtime).
 
 Let's take a look at our Huff contract's output again:
 
@@ -16,6 +16,6 @@ Let's take a look at our Huff contract's output again:
 60008060093d393df3
 ```
 
-Just as expected, we can see the `39` op code 6 places from the right. This is our flag indicating the creation of our Huff contract on-chain!
+Just as expected, we can see the `39` opcode 6 places from the right. This is our flag indicating the creation of our Huff contract on-chain!
 
-I absolutely recommend looking at [**evm.codes**](https://www.evm.codes/?fork=shanghai) for an interactive way to learn more about specific op codes in an interactive way.
+I absolutely recommend looking at [**evm.codes**](https://www.evm.codes/?fork=shanghai) for an interactive way to learn more about specific opcodes in an interactive way.

--- a/courses/formal-verification/1-horse-store/9-evm-the-stack/+page.md
+++ b/courses/formal-verification/1-horse-store/9-evm-the-stack/+page.md
@@ -45,7 +45,7 @@ How does Solidity determine how these variables are handled? Let's reformat our 
    2. How does the EVM know how to interpret/interact with data?
 2. How does Remix know to update the number of horses with this data?
 
-As developers, we usually let Solidity handle these complexities automatically. It silently allocates call data, governs memory usage during execution, and seamlessly switches between variable types. But here's the twist: when coding in low-level bytecode, _we_ are responsible for managing memory allocation.
+As developers, we usually let Solidity handle these complexities automatically. It silently allocates calldata, governs memory usage during execution, and seamlessly switches between variable types. But here's the twist: when coding in low-level bytecode, _we_ are responsible for managing memory allocation.
 
 Let's examine this brilliant visual that prominent developer Pascal shared on Twitter:
 
@@ -57,7 +57,7 @@ For our purposes, our focus will be the areas **Stack**, **Memory**, and **Stora
 
 When we want to perform computations on data, we have to consider where the data will be stored and the order of our computations. Of all the spaces in the image above, the cheapest location for this (from the perspective of gas) is going to be on `the stack`.
 
-If we take a look at the `ADD` op code in [**evm.codes**](https://www.evm.codes/?fork=shanghai) we can see how this addition operation actually works.
+If we take a look at the `ADD` opcode in [**evm.codes**](https://www.evm.codes/?fork=shanghai) we can see how this addition operation actually works.
 
 ![evm-the-stack-2](/formal-verification-1/9-evm-the-stack/evm-the-stack-2.png)
 

--- a/courses/formal-verification/3-gasbad/03-emitting-logs-with-assembly-log-4/+page.md
+++ b/courses/formal-verification/3-gasbad/03-emitting-logs-with-assembly-log-4/+page.md
@@ -50,7 +50,7 @@ In the listItem function, our Assembly block is being used to emit an event, or 
 
 ![emitting-logs-with-assembly-log-41](/formal-verification-3/3-emitting-logs-with-assembly/emitting-logs-with-assembly-log-41.png)
 
-This op code will append our log record with 4 topics and takes 6 stack input elements. Let's consider how this is being used in our contract.
+This opcode will append our log record with 4 topics and takes 6 stack input elements. Let's consider how this is being used in our contract.
 
 ```js
 mstore(0x00, price); // This is storing our price parameter in memory

--- a/courses/formal-verification/3-gasbad/21-mid-lesson-recap/+page.md
+++ b/courses/formal-verification/3-gasbad/21-mid-lesson-recap/+page.md
@@ -26,7 +26,7 @@ persistent ghost mathint listingUpdatesCount{
 
 ### Hooks
 
-We learnt about Hooks! Hooks are used to configure logic which is executed based on particular op codes being executed at run time.
+We learnt about Hooks! Hooks are used to configure logic which is executed based on particular opcodes being executed at run time.
 
 ```js
 hook Sstore s_listings[KEY address nftAddress][KEY uint256 tokenId].price uint256 price {
@@ -34,7 +34,7 @@ hook Sstore s_listings[KEY address nftAddress][KEY uint256 tokenId].price uint25
 }
 ```
 
-We define an op code and the storage variable we want to watch for interaction with. When the prover detects this relationship being manipulated, the defined logic in the hook will be executed. In the above example, we increment our listingUpdatesCount variable.
+We define an opcode and the storage variable we want to watch for interaction with. When the prover detects this relationship being manipulated, the defined logic in the hook will be executed. In the above example, we increment our listingUpdatesCount variable.
 
 It's through the combined used of Hooks and Ghost Variables that we were able to define the invariant we wanted to verify:
 

--- a/courses/formal-verification/3-gasbad/27-section-3-recap/+page.md
+++ b/courses/formal-verification/3-gasbad/27-section-3-recap/+page.md
@@ -89,7 +89,7 @@ HAVOCing is an integral part of Certora proofs. If the prover is able to find a 
 
 ### Hooks
 
-We also learnt that any time our protocol executes any number of op codes, we can configure Certora hooks to perform custom actions when executed. We demonstrated this by hooking SSTORE and LOG4 opcodes and used them to increment our ghost variables to be compared!
+We also learnt that any time our protocol executes any number of opcodes, we can configure Certora hooks to perform custom actions when executed. We demonstrated this by hooking SSTORE and LOG4 opcodes and used them to increment our ghost variables to be compared!
 
 ```js
 hook Sstore s_listings[KEY address nftAddress][KEY uint256 tokenId].price uint256 price {


### PR DESCRIPTION
and fix a typo from "simpl" to "simple"

----
Extra info

- calldata:
"calldata" when meaning message call's data (e.g. it can be arbitrary bytes but usually is payload that carries the function selector + arguments)
"call data" when meaning telephone call 😁

- opcode:
"opcode" when abbreviating "operation code"
https://en.wikipedia.org/wiki/Opcode