### PR TITLE
Fix typos across multiple +page.md

### DIFF
--- a/courses/chainlink-fundamentals/2-smart-contract-and-solidity-fundamentals/1-introduction-to-solidity/+page.md
+++ b/courses/chainlink-fundamentals/2-smart-contract-and-solidity-fundamentals/1-introduction-to-solidity/+page.md
@@ -91,7 +91,7 @@ contract StorageExample {
 }
 ```
 
-When you see a variable defined at the contract level like this, it's a state variable that will be stored on the blockchain permenantly. Sometimes, for clarity, we label variables as stored in storage using the `s_` prefix e.g. `s_balance` or `s_owner`.
+When you see a variable defined at the contract level like this, it's a state variable that will be stored on the blockchain permanently. Sometimes, for clarity, we label variables as stored in storage using the `s_` prefix e.g. `s_balance` or `s_owner`.
 
 #### State Variable Visibility
 
@@ -838,7 +838,7 @@ Think of the ABI as a contract's "API documentation" but in a machine-readable f
 
 ### ABI Format
 
-The ABI is a JSON array that describes everything publically visible on a contract.
+The ABI is a JSON array that describes everything publicly visible on a contract.
 
 Let's take a simple example. Take a simple smart contract `Simple Math` that has one function `add` that adds two numbers together:
 

--- a/courses/chainlink-fundamentals/2-smart-contract-and-solidity-fundamentals/3-testnet-funds/+page.md
+++ b/courses/chainlink-fundamentals/2-smart-contract-and-solidity-fundamentals/3-testnet-funds/+page.md
@@ -16,7 +16,7 @@ Let's walk through how to get some testnet LINK, how to add LINK to MetaMask and
 
 - Head to the [Chainlink documentation](https://docs.chain.link/resources/link-token-contracts) and scroll down to the chain you want to use LINK on. E.g. [Sepolia Testnet](https://docs.chain.link/resources/link-token-contracts#sepolia-testnet)
 
-- Click the **Add to wallet** button to import the LINK token to NetaMask. Note that this will only add the token for that secific network. This will need to be repeated for all networks you intend to use LINK tokens.
+- Click the **Add to wallet** button to import the LINK token to NetaMask. Note that this will only add the token for that specific network. This will need to be repeated for all networks you intend to use LINK tokens.
 
 ![add-to-wallet](/chainlink-fundamentals/2-smart-contract-and-solidity-fundamentals/assets/add-to-wallet.png)
 

--- a/courses/chainlink-fundamentals/7-chainlink-functions/2-chainlink-functions-playground/+page.md
+++ b/courses/chainlink-fundamentals/7-chainlink-functions/2-chainlink-functions-playground/+page.md
@@ -25,7 +25,7 @@ The playground has the following fields:
 
 - **Source code**: This is where you put the JavaScript source code you want to test to send in your Chainlink Functions request.
 - **Argument(s)**: Argument(s) to your JavaScript code. Arguments are variables in your JavaScript code, the values in your code you want to change, e.g., the city to retrieve a temperature for or some on-chain data.
-- **Secret(s)**: private arguments, e.g., API keys, credentials, etc. This is the sensitive data you don't want to be publically visible. Chainlink Functions "injects" these values into your JavaScript at "runtime" (when the JavaScript is run).
+- **Secret(s)**: private arguments, e.g., API keys, credentials, etc. This is the sensitive data you don't want to be publicly visible. Chainlink Functions "injects" these values into your JavaScript at "runtime" (when the JavaScript is run).
 
 To run the code:
 


### PR DESCRIPTION
Fix typos across multiple +page.md:

- `permenantly` → `permanently`
- `publically` → `publicly`
- `secific` → `specific`
- `publically` → `publicly`