### PR TITLE
Fix typos across multiple +page.md

### DIFF
--- a/courses/security/6-thunder-loan/40-exploit-oracle-manipulation-thunderloan-poc/+page.md
+++ b/courses/security/6-thunder-loan/40-exploit-oracle-manipulation-thunderloan-poc/+page.md
@@ -14,7 +14,7 @@ Now that we've learnt so much about `oracle manipulation` attacks, we can return
 uint256 valueOfBorrowedToken = (amount * getPriceInWeth(address(token))) / s_feePrecision;
 ```
 
-A possible reason the `Thunder Loan` protocol didn't detect any issues with TSwap is likely due to how poor their mocks are constructed. They don't actually mimick any of the logic of the Dex and thus would be unable to see how the price would change over time.
+A possible reason the `Thunder Loan` protocol didn't detect any issues with TSwap is likely due to how poor their mocks are constructed. They don't actually mimic any of the logic of the Dex and thus would be unable to see how the price would change over time.
 
 I've created new mocks we can use in our test (though often you'll have to build these yourself!)
 

--- a/courses/security/7-bridges/31-recap/+page.md
+++ b/courses/security/7-bridges/31-recap/+page.md
@@ -42,7 +42,7 @@ And, in the process we identified a bunch of new vulnerabilities like `gas bombs
 
 One thing we didn't cover with as much depth was the actual writing of the findings. This is very much intentional. I'm trying to wean you off the hand holding so that you're able to perform reviews solo, confident in your ability to spot all these new exploits in your repertoire.
 
-Another thing we actually didn't cover is the myriad of specific example of bridge hacks that have occured. Hacks like `Ronin`, `Poly Network`, `Nomad`, `Wormhole` - these are $100 Million + hacks. I highly encourage you to familiarize yourself with them, though to be frank - most of them boil down to: **_Centralization is bad_**.
+Another thing we actually didn't cover is the myriad of specific example of bridge hacks that have occurred. Hacks like `Ronin`, `Poly Network`, `Nomad`, `Wormhole` - these are $100 Million + hacks. I highly encourage you to familiarize yourself with them, though to be frank - most of them boil down to: **_Centralization is bad_**.
 
 ### Wrap Up
 

--- a/courses/uniswap-v3/9-fee-algorithm/8-fee-growth-above/+page.md
+++ b/courses/uniswap-v3/9-fee-algorithm/8-fee-growth-above/+page.md
@@ -35,9 +35,9 @@ For the time interval between `t_5` and `t_6`, the fee growth is over here. The 
 
 Lastly, for time interval between `t_6` and `t_7`, the fee growth is over here, and it can be expressed as `f_g6` minus `f_g5` +  `f_g4` minus `f_g3` + `f_g2` minus `f_g1`.
 
-Now we will calculate fee growth outside, by first using the initilization algorithm. This is `f_o,i` =  `f_g` if current tick i is less than or equal to `i_c`. Otherwise, if it is less than i, we initilize it to 0.
+Now we will calculate fee growth outside, by first using the initilization algorithm. This is `f_o,i` =  `f_g` if current tick i is less than or equal to `i_c`. Otherwise, if it is less than i, we initialize it to 0.
 
-When looking at our graph and our example at time `t_0`, we see that the current tick is less than tick i, which means we intialize `f_o,i` to 0.
+When looking at our graph and our example at time `t_0`, we see that the current tick is less than tick i, which means we initialize `f_o,i` to 0.
 When the fee growth crosses tick i at time t1, we apply our update rule `f_o,i` = `f_g` - `f_o,i`. In this case we get `f_g1` minus 0 which is equal to `f_g1`.
 
 We continue this process for the rest of the table.


### PR DESCRIPTION
Fix typos across multiple +page.md:

 - `mimick` → `mimic`
 - `occured` → `occurred`
 - `initilize` → `initialize`