### PR TITLE
build: update checkout action to v6

### DIFF
--- a/.github/workflows/audit_action.yml
+++ b/.github/workflows/audit_action.yml
@@ -21,7 +21,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         env:
           MUX_TOKEN_ID: ${{ secrets.MUX_TOKEN_ID }}
           MUX_TOKEN_SECRET: ${{ secrets.MUX_TOKEN_ID }}


### PR DESCRIPTION
Upgrade to actions/checkout v6 for latest improvements and security fixes.

https://github.com/actions/checkout/releases/tag/v6.0.0