### PR TITLE
Replace legacy image markdown in security course

### DIFF
--- a/courses/security/1-review/11-encoding-function/+page.md
+++ b/courses/security/1-review/11-encoding-function/+page.md
@@ -13,7 +13,7 @@ With the previous lesson's foundation laid, lets look at what encoding is like w
 We know the EVM is looking for this encoded information, this binary _stuff_. And since transactions sent to the blockchain are ultimately compiled down to this binary, what this allows us to do is populate the `Data` property of a transaction with this binary ourselves.
 
 
-::image{src='/security-section-1/11-encoding-function/encoding-function2.png' style='width: 95%; height: auto;' alt='block fee' caption='Remember the properties of a Transaction' captionStyle='font-size: 10px' figureStyle='display: flex; flex-direction: column; align-items: center;'}
+![block fee](/security-section-1/11-encoding-function/encoding-function2.png)
 
 ### ABI Encoding and Transactions
 

--- a/courses/security/1-review/2-solidity-requisites/+page.md
+++ b/courses/security/1-review/2-solidity-requisites/+page.md
@@ -18,7 +18,7 @@ All of the basic Solidity, variable types, contract structure etc should be seco
 
 You should also be familiar with the working environments of Foundry, or your framework of choice. You should understand how to initialize a project in your framework and navigate it's working tree.
 
-::image{src='/security-section-1/2-solidity-req/solidity-prerequisites1.PNG' style='width: 40%; height: auto;' alt='block fee' figureStyle='display: flex; justify-content: center;'}
+![block fee](/security-section-1/2-solidity-req/solidity-prerequisites1.PNG)
 
 Commands like these should ring lots of bells.
 

--- a/courses/security/1-review/6-what-is-erc721/+page.md
+++ b/courses/security/1-review/6-what-is-erc721/+page.md
@@ -21,9 +21,9 @@ As a more relatable analogy, consider an NFT as a distinct piece of art, trading
 Although NFTs are mostly associated with art, they extend beyond that. They can be assigned any property, or manipulated in any way you like, thanks to the underlying smart contract technology.
 
 
-::image{src='/security-section-1/6-erc721s/erc721s1.png' style='width: 20%; height: auto;' alt='block fee' caption='An NFT example from OpenSea' captionSyle='font-size: 10px' figureStyle='display: flex; flex-direction: column; align-items: center;'}
+![block fee](/security-section-1/6-erc721s/erc721s1.png)
 
-::image{src='/security-section-1/6-erc721s/erc721s2.png' style='width: 21.7%; height: auto;' alt='block fee' caption='An NFT example from OpenSea' captionSyle='font-size: 10px' figureStyle='display: flex; flex-direction: column; align-items: center;'}
+![block fee](/security-section-1/6-erc721s/erc721s2.png)
 
 These unique tokens are deployed on a smart contract platform and can be traded on numerous NFT platforms such as [OpenSea](https://opensea.io/) or [Rarible](https://rarible.com/). While these decentralized marketplaces provide user-friendly interfaces for trading NFTs, one could just as easily buy and sell outside of them.
 

--- a/courses/security/1-review/9-fallback-and-receive/+page.md
+++ b/courses/security/1-review/9-fallback-and-receive/+page.md
@@ -14,7 +14,7 @@ These two specific functions - `fallback` and `receive` - enable a contract to a
 
 So, how do they function? Here's the core logic to give you a better understanding:
 
-::image{src='/security-section-1/9-fallback-receive/fallback-receive1.png' style='width: 30%; height: auto;' alt='block fee' figureStyle='display: flex; justify-content: center;'}
+![block fee](/security-section-1/9-fallback-receive/fallback-receive1.png)
 
 To put it simply, consider the case of sending ETH to a smart contract without any data. In such an instance, the `receive` function would be called, resorting to `fallback` if the `receive` function does not exist.
 

--- a/revert_images.sh
+++ b/revert_images.sh
@@ -5,12 +5,12 @@ START_DIR="courses"
 
 # Find all .md files recursively
 find "$START_DIR" -name "*.md" -type f | while read -r file; do
-    # Replace ::image{} syntax with alt attribute (keep existing alt)
-    sed -i '' -E "s|::image\\{src='([^']*)' style='[^']*' alt='([^']*)'\\}|![\2](\1)|g" "$file"
-    
+    # Replace ::image{} syntax with alt attribute and additional attributes (caption, captionStyle, figureStyle, etc.)
+    sed -i '' -E "s|::image\\{src='([^']*)' style='[^']*' alt='([^']*)'[^}]*\\}|![\2](\1)|g" "$file"
+
     # Replace ::image{} syntax without alt attribute (extract just filename without extension for alt)
-    sed -i '' -E "s|::image\\{src='([^']*)/([^/]*)\\.([^']*)'[ ]*style='[^']*'\\}|![\2](\1/\2.\3)|g" "$file"
-    
+    sed -i '' -E "s|::image\\{src='([^']*)/([^/]*)\\.([^']*)'[ ]*style='[^']*'[^}]*\\}|![\2](\1/\2.\3)|g" "$file"
+
     echo "Processed: $file"
 done
 


### PR DESCRIPTION
Adjust 'revert_images.sh' script and use it to replace remaining legacy image markdown