### PR TITLE
Fix minor documentation typos

### DIFF
--- a/courses/advanced-foundry/2-how-to-create-an-NFT-collection/7-basic-nft-tests/+page.md
+++ b/courses/advanced-foundry/2-how-to-create-an-NFT-collection/7-basic-nft-tests/+page.md
@@ -73,7 +73,7 @@ Now if you type `cat`, you should get a kinda crazy output that's representing t
 
 ![basic-nft-tests2](/foundry-nfts/7-basic-nft-tests/basic-nft-tests2.png)
 
-We'll leverage abi.encodePacked to convert this to bytes, then finally we can use keccak256 to hash the value into bytes32, which we can can use in our value comparison.
+We'll leverage abi.encodePacked to convert this to bytes, then finally we can use keccak256 to hash the value into bytes32, which we can use in our value comparison.
 
 ![basic-nft-tests3](/foundry-nfts/7-basic-nft-tests/basic-nft-tests3.png)
 

--- a/courses/advanced-foundry/3-develop-defi-protocol/11-defi-deploy-script/+page.md
+++ b/courses/advanced-foundry/3-develop-defi-protocol/11-defi-deploy-script/+page.md
@@ -231,7 +231,7 @@ With the HelperConfig complete, we can return to DeployDSC.s.sol. Please referen
 
 ### Back to DeployDSC
 
-Returning to `DeployDSC.s.sol`, we can now import our HelperConfig and use it to acquire the the parameters for our deployments.
+Returning to `DeployDSC.s.sol`, we can now import our HelperConfig and use it to acquire the parameters for our deployments.
 
 ```solidity
 // SPDX-License-Identifier: UNLICENSED

--- a/courses/advanced-foundry/8-daos/1-introduction-to-dao/+page.md
+++ b/courses/advanced-foundry/8-daos/1-introduction-to-dao/+page.md
@@ -116,7 +116,7 @@ What if I told you, you could sign a transaction and vote in a decentralized way
 
 Transactions can actually be signed without being sent to the blockchain. What this means is a protocol could take a bunch of signed transactions, uploaded to a decentralized database (like IPFS), calculate the votes and then batch submit them to the blockchain, maybe even leveraging an oracle to ensure decentrality. This can reduce voting costs by up to 99%!
 
-It's important to be careful the the implementation of any off-chain features, if you introduce a centralized component, the decentrality of your DECENTRALIZED autonomous organization goes away.
+It's important to be careful with the implementation of any off-chain features, if you introduce a centralized component, the decentrality of your DECENTRALIZED autonomous organization goes away.
 
 ### Tools
 

--- a/courses/formal-verification/3-gasbad/25-finishing-the-rule/+page.md
+++ b/courses/formal-verification/3-gasbad/25-finishing-the-rule/+page.md
@@ -226,7 +226,7 @@ With this adjustment in place, we can run the prover again.
 
 ![finishing-the-rule3](/formal-verification-3/25-finishing-the-rule/finishing-the-rule3.png)
 
-It looks like it found a bunch of violations, but the CLI output doesn't provide many details, we should dig deeper into the calls and investigate. If we turn the the `Certora` UI, we can see that a huge number of our function calls failed their `sanity` check!
+It looks like it found a bunch of violations, but the CLI output doesn't provide many details, we should dig deeper into the calls and investigate. If we turn to the `Certora` UI, we can see that a huge number of our function calls failed their `sanity` check!
 
 ![finishing-the-rule4](/formal-verification-3/25-finishing-the-rule/finishing-the-rule4.png)
 


### PR DESCRIPTION
Fixes minor grammatical errors across documentation:

1. Changed "can use" → "can use" (removed word "can")
2. Changed "the the" → "with the" (removed duplicate word)  
3. Changed "the the" → "to the" (corrected duplicate and preposition)