### PR TITLE
Fix command path for finding hook salt

### DIFF
--- a/courses/uniswap-v4/4-hooks/5-exercise-counter-hook/+page.md
+++ b/courses/uniswap-v4/4-hooks/5-exercise-counter-hook/+page.md
@@ -52,7 +52,7 @@ counts[key.toId()]["beforeSwap"]
 1. Find the value of `salt` needed to deploy the hooks contract at a valid address.
 
 ```shell
-forge test --match-path test/FindHookAddr.sol -vvv
+forge test --match-path test/FindHookSalt.test.sol -vvv
 ```
 
 2. Export the salt printed to your terminal from executing the command in the previous step.


### PR DESCRIPTION
Updated the command to find the salt for deploying the hooks contract. The current command refers to the file `test/FindHookAddr.sol` which does not exist